### PR TITLE
Implementera child-struktur   

### DIFF
--- a/backend/src/main/java/se/mistral/backend/child/Child.java
+++ b/backend/src/main/java/se/mistral/backend/child/Child.java
@@ -1,0 +1,22 @@
+package se.mistral.backend.child;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "children")
+public class Child {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String name;
+}

--- a/backend/src/main/java/se/mistral/backend/child/ChildController.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildController.java
@@ -1,0 +1,34 @@
+package se.mistral.backend.child;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import se.mistral.backend.child.dto.ChildResponse;
+import se.mistral.backend.child.dto.CreateChildRequest;
+import java.util.List;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@RequestMapping("/api/children")
+@RestController
+public class ChildController {
+    
+    private final ChildService childService;
+
+    public ChildController(ChildService childService) {
+        this.childService = childService;
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<ChildResponse> createChild(@RequestBody CreateChildRequest request) {
+        return ResponseEntity.ok(childService.createChild(request));
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<ChildResponse>> getAllChildren() {
+        return ResponseEntity.ok(childService.getAllChildren());
+    }
+}

--- a/backend/src/main/java/se/mistral/backend/child/ChildController.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.RequiredArgsConstructor;
 import se.mistral.backend.child.dto.ChildResponse;
 import se.mistral.backend.child.dto.CreateChildRequest;
 import java.util.List;
@@ -12,15 +13,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 
 
+@RequiredArgsConstructor
 @RequestMapping("/api/children")
 @RestController
 public class ChildController {
     
     private final ChildService childService;
-
-    public ChildController(ChildService childService) {
-        this.childService = childService;
-    }
 
     @PostMapping("/")
     public ResponseEntity<ChildResponse> createChild(@RequestBody CreateChildRequest request) {

--- a/backend/src/main/java/se/mistral/backend/child/ChildRepository.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildRepository.java
@@ -1,0 +1,10 @@
+package se.mistral.backend.child;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChildRepository extends JpaRepository<Child, Long> {
+    // findAll() finns redan inbyggt, inget behövs läggas till
+}
+

--- a/backend/src/main/java/se/mistral/backend/child/ChildRepository.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildRepository.java
@@ -5,6 +5,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChildRepository extends JpaRepository<Child, Long> {
-    // findAll() finns redan inbyggt, inget behövs läggas till
 }
 

--- a/backend/src/main/java/se/mistral/backend/child/ChildService.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildService.java
@@ -2,24 +2,20 @@ package se.mistral.backend.child;
 
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
 import se.mistral.backend.child.dto.ChildResponse;
 import se.mistral.backend.child.dto.CreateChildRequest;
 import java.util.List;
-import java.util.stream.Collectors;
 
-
+@RequiredArgsConstructor
 @Service
 public class ChildService {
 
     private final ChildRepository childRepository;
-
-    public ChildService(ChildRepository childRepository) {
-        this.childRepository = childRepository;
-    }
     
     public ChildResponse createChild(CreateChildRequest request) {
         Child child = new Child();
-        child.setName(request.getName());
+        child.setName(request.name());
         Child saved = childRepository.save(child);
         return new ChildResponse(saved.getId(), saved.getName());
     }
@@ -27,6 +23,6 @@ public class ChildService {
         public List<ChildResponse> getAllChildren() {
             return childRepository.findAll().stream()
                     .map(child -> new ChildResponse(child.getId(), child.getName()))
-                    .collect(Collectors.toList());
+                    .toList();
         }
 }

--- a/backend/src/main/java/se/mistral/backend/child/ChildService.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildService.java
@@ -1,0 +1,32 @@
+package se.mistral.backend.child;
+
+import org.springframework.stereotype.Service;
+
+import se.mistral.backend.child.dto.ChildResponse;
+import se.mistral.backend.child.dto.CreateChildRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+public class ChildService {
+
+    private final ChildRepository childRepository;
+
+    public ChildService(ChildRepository childRepository) {
+        this.childRepository = childRepository;
+    }
+    
+    public ChildResponse createChild(CreateChildRequest request) {
+        Child child = new Child();
+        child.setName(request.getName());
+        Child saved = childRepository.save(child);
+        return new ChildResponse(saved.getId(), saved.getName());
+    }
+
+        public List<ChildResponse> getAllChildren() {
+            return childRepository.findAll().stream()
+                    .map(child -> new ChildResponse(child.getId(), child.getName()))
+                    .collect(Collectors.toList());
+        }
+}

--- a/backend/src/main/java/se/mistral/backend/child/dto/ChildResponse.java
+++ b/backend/src/main/java/se/mistral/backend/child/dto/ChildResponse.java
@@ -1,12 +1,7 @@
 package se.mistral.backend.child.dto;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class ChildResponse {
-    private Long id;
-    private String name;
-}
+public record ChildResponse(
+    Long id,
+    String name
+) {}
+

--- a/backend/src/main/java/se/mistral/backend/child/dto/ChildResponse.java
+++ b/backend/src/main/java/se/mistral/backend/child/dto/ChildResponse.java
@@ -1,0 +1,12 @@
+package se.mistral.backend.child.dto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChildResponse {
+    private Long id;
+    private String name;
+}

--- a/backend/src/main/java/se/mistral/backend/child/dto/CreateChildRequest.java
+++ b/backend/src/main/java/se/mistral/backend/child/dto/CreateChildRequest.java
@@ -1,15 +1,8 @@
 package se.mistral.backend.child.dto;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import jakarta.validation.constraints.NotBlank;
 
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class CreateChildRequest {
+public record CreateChildRequest(
     
     @NotBlank
-    private String name;
-}
+    String name){}

--- a/backend/src/main/java/se/mistral/backend/child/dto/CreateChildRequest.java
+++ b/backend/src/main/java/se/mistral/backend/child/dto/CreateChildRequest.java
@@ -1,0 +1,15 @@
+package se.mistral.backend.child.dto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateChildRequest {
+    
+    @NotBlank
+    private String name;
+}

--- a/backend/src/main/java/se/mistral/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/se/mistral/backend/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/api/auth/**").permitAll() // TODO: give different roles different endpoint perms
+                    .requestMatchers("/api/children/**").hasRole("TEACHER")
                     .anyRequest().authenticated()
             )
             .authenticationProvider(authenticationProvider)


### PR DESCRIPTION
Lägger till grundstrukturen för child-domänen. Inkluderar Child-entitet, repository, service och 
  controller med endpoints för att skapa och hämta barn (POST /api/children/, GET /api/children/). 
  Uppdaterar även SecurityConfig för de nya rutterna.   