### PR TITLE
add cascade deletion on the child id foreign key in the attendance table

### DIFF
--- a/backend/src/main/resources/db/migration/V5__add_cascade_to_attendace.sql
+++ b/backend/src/main/resources/db/migration/V5__add_cascade_to_attendace.sql
@@ -1,0 +1,8 @@
+ALTER TABLE attendance
+DROP CONSTRAINT check_child_existence;
+
+ALTER TABLE attendance
+ADD CONSTRAINT check_child_existence
+FOREIGN KEY (child_id)
+REFERENCES children(id)
+ON DELETE CASCADE;


### PR DESCRIPTION
Tänkte att det kan vara bra att ha cascade delete på attendance tabellen. På så sätt kommer alla attendance entries för barn som vi vill ta bort automatiskt försvinna i samband med att man raderar barnet.