### PR TITLE
add endpoint for jwt validation

### DIFF
--- a/backend/src/main/java/se/mistral/backend/auth/AuthController.java
+++ b/backend/src/main/java/se/mistral/backend/auth/AuthController.java
@@ -22,4 +22,9 @@ public class AuthController {
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
     }
+
+    @GetMapping("/validate")
+    public ResponseEntity<Boolean> validateToken() {
+        return ResponseEntity.ok(true);
+    }
 }

--- a/backend/src/main/java/se/mistral/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/se/mistral/backend/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/api/auth/**").permitAll() // TODO: give different roles different endpoint perms
+                    .requestMatchers("/api/auth/validate").authenticated()
                     .requestMatchers("/api/children/**").hasRole("TEACHER")
                     .anyRequest().authenticated()
             )


### PR DESCRIPTION
Ett `GET`-request till `/api/auth/validate` kommer skicka tillbaka `true` med status `200` om token är valid, annars `401` eller `403` beroende på hur spring hanterar det.