### PR TITLE
Feature/operational transformation

### DIFF
--- a/backend/src/main/java/se/mistral/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/se/mistral/backend/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll() // TODO: give different roles different endpoint perms
                 .requestMatchers("/api/children/**").hasRole("TEACHER")
                 .requestMatchers("/api/attendance/**").hasRole("TEACHER")
+                .requestMatchers("/api/journal/**").hasRole("TEACHER")
                 .requestMatchers("/ws").permitAll() // authentication happens inside handler
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()

--- a/backend/src/main/java/se/mistral/backend/journal/Journal.java
+++ b/backend/src/main/java/se/mistral/backend/journal/Journal.java
@@ -1,0 +1,42 @@
+package se.mistral.backend.journal;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "journals", uniqueConstraints = {@UniqueConstraint(name = "UniqueChildIdAndDate", columnNames = {"child_id", "date"})
+})
+public class Journal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "child_id", nullable = false)
+    private Long childId;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Version
+    private int version;
+}

--- a/backend/src/main/java/se/mistral/backend/journal/JournalController.java
+++ b/backend/src/main/java/se/mistral/backend/journal/JournalController.java
@@ -1,0 +1,24 @@
+package se.mistral.backend.journal;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import se.mistral.backend.journal.dto.JournalDto;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/journal")
+@RequiredArgsConstructor
+public class JournalController {
+
+    private final JournalService journalService;
+
+    @GetMapping
+    public ResponseEntity<JournalDto> getJournal(@RequestParam Long childId, @RequestParam(required = false) LocalDate date) {
+        return ResponseEntity.ok(journalService.getOrCreate(childId, date != null ? date : LocalDate.now()));
+    }
+}

--- a/backend/src/main/java/se/mistral/backend/journal/JournalRepository.java
+++ b/backend/src/main/java/se/mistral/backend/journal/JournalRepository.java
@@ -1,0 +1,13 @@
+package se.mistral.backend.journal;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface JournalRepository extends JpaRepository<Journal, Long> {
+
+    Optional<Journal> findByChildIdAndDate(Long childId, LocalDate date);
+}

--- a/backend/src/main/java/se/mistral/backend/journal/JournalService.java
+++ b/backend/src/main/java/se/mistral/backend/journal/JournalService.java
@@ -36,7 +36,7 @@ public class JournalService {
 
     public BroadcastMessage applyOperation(Long childId, LocalDate date,
                                            int clientRevision, Operation incoming,
-                                           Long userId) {
+                                           Long userId, Integer seq) {
         // get the journal id outside the lock
         Journal journal = findOrCreate(childId, date);
         Object lock = journalLocks.computeIfAbsent(journal.getId(), k -> new Object());
@@ -68,7 +68,7 @@ public class JournalService {
                     .appliedAt(Instant.now())
                     .build());
 
-            return new BroadcastMessage("DOC_OPERATION", transformed, journal.getVersion());
+            return new BroadcastMessage("DOC_OPERATION", transformed, journal.getVersion(), userId, seq);
         }
     }
 

--- a/backend/src/main/java/se/mistral/backend/journal/JournalService.java
+++ b/backend/src/main/java/se/mistral/backend/journal/JournalService.java
@@ -1,0 +1,103 @@
+package se.mistral.backend.journal;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import se.mistral.backend.journal.dto.BroadcastMessage;
+import se.mistral.backend.journal.dto.JournalDto;
+import se.mistral.backend.journal.ot.Operation;
+import se.mistral.backend.journal.ot.OperationLog;
+import se.mistral.backend.journal.ot.OperationLogRepository;
+import se.mistral.backend.journal.ot.OperationTransformer;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static se.mistral.backend.journal.ot.Operation.Type.INSERT;
+import static se.mistral.backend.journal.ot.Operation.Type.DELETE;
+
+@Service
+@RequiredArgsConstructor
+public class JournalService {
+
+    private final JournalRepository journalRepository;
+    private final OperationLogRepository operationLogRepository;
+    private final OperationTransformer operationTransformer;
+
+    // one lock object per journal to only sync threads editing the same document
+    private final ConcurrentHashMap<Long, Object> journalLocks = new ConcurrentHashMap<>();
+
+    public JournalDto getOrCreate(Long childId, LocalDate date) {
+        Journal journal = findOrCreate(childId, date);
+        return new JournalDto(journal.getContent(), journal.getVersion());
+    }
+
+    public BroadcastMessage applyOperation(Long childId, LocalDate date,
+                                           int clientRevision, Operation incoming,
+                                           Long userId) {
+        // get the journal id outside the lock
+        Journal journal = findOrCreate(childId, date);
+        Object lock = journalLocks.computeIfAbsent(journal.getId(), k -> new Object());
+
+        synchronized (lock) {
+            journal = journalRepository.findById(journal.getId()).orElseThrow();
+
+            List<OperationLog> missed = operationLogRepository
+                    .findByJournalIdAndRevisionGreaterThanOrderByRevisionAsc(
+                            journal.getId(), clientRevision);
+
+            // transform the incoming op through each missed op in order
+            Operation transformed = incoming;
+            for (OperationLog concurrent : missed) {
+                transformed = operationTransformer.transform(transformed, concurrent.toOperation());
+            }
+
+            journal.setContent(applyToString(journal.getContent(), transformed));
+            journal = journalRepository.save(journal);
+
+            operationLogRepository.save(OperationLog.builder()
+                    .journalId(journal.getId())
+                    .revision(journal.getVersion())
+                    .opType(transformed.getType())
+                    .position(transformed.getPosition())
+                    .text(transformed.getText())
+                    .length(transformed.getLength())
+                    .userId(userId)
+                    .appliedAt(Instant.now())
+                    .build());
+
+            return new BroadcastMessage("DOC_OPERATION", transformed, journal.getVersion());
+        }
+    }
+
+    // handles the race condition where two sessions open the same journal simultaneously
+    private Journal findOrCreate(Long childId, LocalDate date) {
+        return journalRepository.findByChildIdAndDate(childId, date)
+                .orElseGet(() -> {
+                    try {
+                        return journalRepository.save(
+                                Journal.builder()
+                                        .childId(childId)
+                                        .date(date)
+                                        .content("")
+                                        .build());
+                    } catch (DataIntegrityViolationException e) {
+                        return journalRepository.findByChildIdAndDate(childId, date).orElseThrow();
+                    }
+                });
+    }
+
+    private String applyToString(String content, Operation op) {
+        int pos = Math.max(0, Math.min(op.getPosition(), content.length()));
+
+        return switch (op.getType()) {
+            case INSERT -> content.substring(0, pos) + op.getText() + content.substring(pos);
+            case DELETE -> {
+                int end = Math.min(pos + op.getLength(), content.length());
+                yield content.substring(0, pos) + content.substring(end);
+            }
+        };
+    }
+}

--- a/backend/src/main/java/se/mistral/backend/journal/JournalService.java
+++ b/backend/src/main/java/se/mistral/backend/journal/JournalService.java
@@ -3,6 +3,8 @@ package se.mistral.backend.journal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+
+import se.mistral.backend.exception.NotFoundException;
 import se.mistral.backend.journal.dto.BroadcastMessage;
 import se.mistral.backend.journal.dto.JournalDto;
 import se.mistral.backend.journal.ot.Operation;
@@ -36,13 +38,13 @@ public class JournalService {
 
     public BroadcastMessage applyOperation(Long childId, LocalDate date,
                                            int clientRevision, Operation incoming,
-                                           Long userId, Integer seq) {
+                                           Long userId, Integer sequence) {
         // get the journal id outside the lock
         Journal journal = findOrCreate(childId, date);
         Object lock = journalLocks.computeIfAbsent(journal.getId(), k -> new Object());
 
         synchronized (lock) {
-            journal = journalRepository.findById(journal.getId()).orElseThrow();
+            journal = journalRepository.findById(journal.getId()).orElseThrow(() -> new NotFoundException("Journal could not be found"));
 
             List<OperationLog> missed = operationLogRepository
                     .findByJournalIdAndRevisionGreaterThanOrderByRevisionAsc(
@@ -68,7 +70,7 @@ public class JournalService {
                     .appliedAt(Instant.now())
                     .build());
 
-            return new BroadcastMessage("DOC_OPERATION", transformed, journal.getVersion(), userId, seq);
+            return new BroadcastMessage("DOC_OPERATION", transformed, journal.getVersion(), userId, sequence);
         }
     }
 
@@ -84,7 +86,8 @@ public class JournalService {
                                         .content("")
                                         .build());
                     } catch (DataIntegrityViolationException e) {
-                        return journalRepository.findByChildIdAndDate(childId, date).orElseThrow();
+                        return journalRepository.findByChildIdAndDate(childId, date)
+                            .orElseThrow(() -> new NotFoundException("Journal could not be found")); // this will never be thrown
                     }
                 });
     }

--- a/backend/src/main/java/se/mistral/backend/journal/dto/BroadcastMessage.java
+++ b/backend/src/main/java/se/mistral/backend/journal/dto/BroadcastMessage.java
@@ -7,5 +7,5 @@ public record BroadcastMessage(
     Operation operation,  // the transformed op
     int serverRevision,   // clients update their local revision to this value
     Long userId,          // required to decide whether to check in-flight buff locally
-    Integer seq           // used by client to keep track of change locally
+    Integer sequence      // used by client to keep track of change locally
 ) { }

--- a/backend/src/main/java/se/mistral/backend/journal/dto/BroadcastMessage.java
+++ b/backend/src/main/java/se/mistral/backend/journal/dto/BroadcastMessage.java
@@ -1,0 +1,9 @@
+package se.mistral.backend.journal.dto;
+
+import se.mistral.backend.journal.ot.Operation;
+
+public record BroadcastMessage(
+    String type,         // always "DOC_OPERATION"
+    Operation operation, // the transformed op
+    int serverRevision   // clients update their local revision to this value
+) { }

--- a/backend/src/main/java/se/mistral/backend/journal/dto/BroadcastMessage.java
+++ b/backend/src/main/java/se/mistral/backend/journal/dto/BroadcastMessage.java
@@ -3,7 +3,9 @@ package se.mistral.backend.journal.dto;
 import se.mistral.backend.journal.ot.Operation;
 
 public record BroadcastMessage(
-    String type,         // always "DOC_OPERATION"
-    Operation operation, // the transformed op
-    int serverRevision   // clients update their local revision to this value
+    String type,          // always "DOC_OPERATION"
+    Operation operation,  // the transformed op
+    int serverRevision,   // clients update their local revision to this value
+    Long userId,          // required to decide whether to check in-flight buff locally
+    Integer seq           // used by client to keep track of change locally
 ) { }

--- a/backend/src/main/java/se/mistral/backend/journal/dto/JournalDto.java
+++ b/backend/src/main/java/se/mistral/backend/journal/dto/JournalDto.java
@@ -1,0 +1,6 @@
+package se.mistral.backend.journal.dto;
+
+public record JournalDto(
+    String content,
+    int serverRevision  // user stores this and sends it back with each operation
+) { }

--- a/backend/src/main/java/se/mistral/backend/journal/ot/Operation.java
+++ b/backend/src/main/java/se/mistral/backend/journal/ot/Operation.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Operation {

--- a/backend/src/main/java/se/mistral/backend/journal/ot/Operation.java
+++ b/backend/src/main/java/se/mistral/backend/journal/ot/Operation.java
@@ -15,6 +15,6 @@ public class Operation {
 
     private Type type;
     private int position;
-    private String text;    // populated for INSERT, null for DELETE
-    private int length;     // populated for DELETE, 0 for INSERT
+    private String text;     // nullable for DELETE
+    private Integer length;  // nullable for INSERT
 }

--- a/backend/src/main/java/se/mistral/backend/journal/ot/Operation.java
+++ b/backend/src/main/java/se/mistral/backend/journal/ot/Operation.java
@@ -1,0 +1,20 @@
+package se.mistral.backend.journal.ot;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Operation {
+
+    public enum Type { INSERT, DELETE }
+
+    private Type type;
+    private int position;
+    private String text;    // populated for INSERT, null for DELETE
+    private int length;     // populated for DELETE, 0 for INSERT
+}

--- a/backend/src/main/java/se/mistral/backend/journal/ot/OperationLog.java
+++ b/backend/src/main/java/se/mistral/backend/journal/ot/OperationLog.java
@@ -1,0 +1,62 @@
+package se.mistral.backend.journal.ot;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "operation_log")
+public class OperationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "journal_id", nullable = false)
+    private Long journalId;
+
+    @Column(nullable = false)
+    private int revision;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "op_type", nullable = false)
+    private Operation.Type opType;
+
+    @Column(nullable = false)
+    private int position;
+
+    private String text;
+
+    private Integer length;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "applied_at", nullable = false)
+    private Instant appliedAt;
+
+    // reconstruct an Operation object from this log row
+    public Operation toOperation() {
+        return Operation.builder()
+                .type(opType)
+                .position(position)
+                .text(text)
+                .length(length != null ? length : 0)
+                .build();
+    }
+}

--- a/backend/src/main/java/se/mistral/backend/journal/ot/OperationLogRepository.java
+++ b/backend/src/main/java/se/mistral/backend/journal/ot/OperationLogRepository.java
@@ -1,0 +1,14 @@
+package se.mistral.backend.journal.ot;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OperationLogRepository extends JpaRepository<OperationLog, Long> {
+
+    // fetches every server op the client has NOT yet seen, in the order they were applied.
+    List<OperationLog> findByJournalIdAndRevisionGreaterThanOrderByRevisionAsc(
+            Long journalId, int revision);
+}

--- a/backend/src/main/java/se/mistral/backend/journal/ot/OperationTransformer.java
+++ b/backend/src/main/java/se/mistral/backend/journal/ot/OperationTransformer.java
@@ -54,21 +54,21 @@ public class OperationTransformer {
                 }
             }
             case DELETE -> {
-                int cPos = concurrent.getPosition();
-                int cLen = concurrent.getLength();
+                int concurrentPos = concurrent.getPosition();
+                int concurrentLen = concurrent.getLength();
 
-                if (cPos + cLen <= pos) {
+                if (concurrentPos + concurrentLen <= pos) {
                     // concurrent delete is entirely before us: shift left
-                    pos -= cLen;
-                } else if (cPos >= pos + len) {
+                    pos -= concurrentLen;
+                } else if (concurrentPos >= pos + len) {
                     // concurrent delete is entirely after us: no change needed
                 } else {
                     // ranges overlap: shrink our delete by the overlapping characters
                     // that the concurrent op already removed
-                    int overlapStart = Math.max(pos, cPos);
-                    int overlapEnd   = Math.min(pos + len, cPos + cLen);
+                    int overlapStart = Math.max(pos, concurrentPos);
+                    int overlapEnd   = Math.min(pos + len, concurrentPos + concurrentLen);
                     len -= (overlapEnd - overlapStart);
-                    pos  = Math.min(pos, cPos);
+                    pos  = Math.min(pos, concurrentPos);
                 }
             }
         }

--- a/backend/src/main/java/se/mistral/backend/journal/ot/OperationTransformer.java
+++ b/backend/src/main/java/se/mistral/backend/journal/ot/OperationTransformer.java
@@ -1,0 +1,78 @@
+package se.mistral.backend.journal.ot;
+
+import org.springframework.stereotype.Component;
+
+import static se.mistral.backend.journal.ot.Operation.Type.INSERT;
+import static se.mistral.backend.journal.ot.Operation.Type.DELETE;
+
+@Component
+public class OperationTransformer {
+
+    // returns `incoming` adjusted so it applies correctly after `concurrent`
+    // has already been applied to the document.
+    public Operation transform(Operation incoming, Operation concurrent) {
+        return switch (incoming.getType()) {
+            case INSERT -> transformInsert(incoming, concurrent);
+            case DELETE -> transformDelete(incoming, concurrent);
+        };
+    }
+
+    private Operation transformInsert(Operation incoming, Operation concurrent) {
+        int pos = incoming.getPosition();
+
+        switch (concurrent.getType()) {
+            case INSERT -> {
+                // concurrent insert at or before our position pushes us right
+                if (concurrent.getPosition() <= pos) {
+                    pos += concurrent.getText().length();
+                }
+            }
+            case DELETE -> {
+                // concurrent delete before our position pulls us left,
+                // but never past the start of the deleted range
+                if (concurrent.getPosition() < pos) {
+                    pos = Math.max(concurrent.getPosition(), pos - concurrent.getLength());
+                }
+            }
+        }
+
+        return incoming.toBuilder().position(pos).build();
+    }
+
+    private Operation transformDelete(Operation incoming, Operation concurrent) {
+        int pos = incoming.getPosition();
+        int len = incoming.getLength();
+
+        switch (concurrent.getType()) {
+            case INSERT -> {
+                if (concurrent.getPosition() <= pos) {
+                    // concurrent insert is entirely before us: shift right
+                    pos += concurrent.getText().length();
+                } else if (concurrent.getPosition() < pos + len) {
+                    // concurrent insert is inside our range: our delete gets longer
+                    len += concurrent.getText().length();
+                }
+            }
+            case DELETE -> {
+                int cPos = concurrent.getPosition();
+                int cLen = concurrent.getLength();
+
+                if (cPos + cLen <= pos) {
+                    // concurrent delete is entirely before us: shift left
+                    pos -= cLen;
+                } else if (cPos >= pos + len) {
+                    // concurrent delete is entirely after us: no change needed
+                } else {
+                    // ranges overlap: shrink our delete by the overlapping characters
+                    // that the concurrent op already removed
+                    int overlapStart = Math.max(pos, cPos);
+                    int overlapEnd   = Math.min(pos + len, cPos + cLen);
+                    len -= (overlapEnd - overlapStart);
+                    pos  = Math.min(pos, cPos);
+                }
+            }
+        }
+
+        return incoming.toBuilder().position(pos).length(Math.max(0, len)).build();
+    }
+}

--- a/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
+++ b/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
@@ -98,12 +98,15 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
             return;
         }
 
+        Integer clientSeq = json.has("seq") ? json.get("seq").asInt() : null;
+
         BroadcastMessage broadcast = journalService.applyOperation(
             childId,
             date,
             clientRevision,
             incoming,
-            userId
+            userId,
+            clientSeq
         );
 
         // null sender so the originator also receives the message

--- a/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
+++ b/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
@@ -98,7 +98,7 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
             return;
         }
 
-        Integer clientSeq = json.has("seq") ? json.get("seq").asInt() : null;
+        Integer clientSequence = json.has("sequence") ? json.get("sequence").asInt() : null;
 
         BroadcastMessage broadcast = journalService.applyOperation(
             childId,
@@ -106,7 +106,7 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
             clientRevision,
             incoming,
             userId,
-            clientSeq
+            clientSequence
         );
 
         // null sender so the originator also receives the message

--- a/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
+++ b/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
@@ -1,6 +1,7 @@
 package se.mistral.backend.websocket;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,6 +16,9 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import lombok.RequiredArgsConstructor;
 import se.mistral.backend.auth.JwtService;
+import se.mistral.backend.journal.JournalService;
+import se.mistral.backend.journal.dto.BroadcastMessage;
+import se.mistral.backend.journal.ot.Operation;
 import se.mistral.backend.user.Role;
 import se.mistral.backend.user.User;
 import tools.jackson.databind.JsonNode;
@@ -26,6 +30,8 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
+    private final JournalService journalService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final Map<String, Set<WebSocketSession>> rooms = new ConcurrentHashMap<>(); // all sessions in a given room
@@ -38,9 +44,10 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
         String room = json.get("room").asText();
 
         switch (type) {
-            case "subscribe"   -> subscribe(session, room);
-            case "unsubscribe" -> unsubscribe(session, room);
-            default            -> broadcastToRoom(session, room, message);
+            case "subscribe"      -> subscribe(session, room);
+            case "unsubscribe"    -> unsubscribe(session, room);
+            case "DOC_OPERATION"  -> handleDocOperation(session, room, json);
+            default               -> broadcastToRoom(session, room, message);
         }
     }
 
@@ -51,6 +58,11 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
             closeQuietly(session);
             return;
         }
+
+        // store userId to not have to send it for each message
+        Long userId = extractUserId(token);
+        session.getAttributes().put("userId", userId);
+
         sessionRooms.putIfAbsent(session, ConcurrentHashMap.newKeySet());
     }
 
@@ -63,6 +75,43 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
 
         for (String room : joined) {
             removeSessionFromRoom(room, session);
+        }
+    }
+
+    private void handleDocOperation(WebSocketSession session, String room, JsonNode json) {
+        // room format: "journal:{childId}:{date}"  e.g. "journal:42:2025-04-22"
+        String[] parts = room.split(":");
+        if (parts.length != 3 || !parts[0].equals("journal")) {
+            closeQuietly(session);
+            return;
+        }
+
+        Long childId = Long.parseLong(parts[1]);
+        LocalDate date = LocalDate.parse(parts[2]);
+        int clientRevision = json.get("clientRevision").asInt();
+        Long userId = (Long) session.getAttributes().get("userId");
+
+        Operation incoming;
+        try {
+            incoming = objectMapper.treeToValue(json.get("operation"), Operation.class);
+        } catch (Exception e) {
+            return;
+        }
+
+        BroadcastMessage broadcast = journalService.applyOperation(
+            childId,
+            date,
+            clientRevision,
+            incoming,
+            userId
+        );
+
+        // null sender so the originator also receives the message
+        try {
+            TextMessage outbound = new TextMessage(objectMapper.writeValueAsString(broadcast));
+            broadcastToRoom(null, room, outbound);
+        } catch (Exception e) {
+            // serialization failure shouldn't crash the handler
         }
     }
 
@@ -128,6 +177,16 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
             return appUser.getRole() == Role.TEACHER;
         } catch (Exception e) {
             return false;
+        }
+    }
+
+    private Long extractUserId(String token) {
+        try {
+            String email = jwtService.extractUsername(token);
+            User user = (User) userDetailsService.loadUserByUsername(email);
+            return user.getId();
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/backend/src/main/resources/db/migration/V10__create_journals_table.sql
+++ b/backend/src/main/resources/db/migration/V10__create_journals_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE journals (
+    id BIGSERIAL PRIMARY KEY,
+    child_id BIGINT NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+    date DATE NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    version INT NOT NULL DEFAULT 0,
+    UNIQUE (child_id, date)
+);

--- a/backend/src/main/resources/db/migration/V11__create_operation_log_table.sql
+++ b/backend/src/main/resources/db/migration/V11__create_operation_log_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE operation_log (
+    id BIGSERIAL PRIMARY KEY,
+    journal_id BIGINT NOT NULL REFERENCES journals(id) ON DELETE CASCADE,
+    revision INT NOT NULL,
+    op_type VARCHAR(10) NOT NULL,
+    position INT NOT NULL,
+    text TEXT,
+    length INT,
+    user_id BIGINT REFERENCES users(id),
+    applied_at TIMESTAMP NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
Jag har implementerat OT genom vår WebSocket implementering. För tillfället går det att hantera dagliga journaler per barn. Jag skriver en guide här under för de som ska jobba med att integrera det här i frontenden sen så ni har koll på allt ni behöver veta.

# Integrationsguide för frontend teamet
Backenden håller koll på journalens faktiska tillstånd och är därför den som bestämmer hur operationer ska appliceras i journalen. Varje operation som en klient skickar måste därför passera servern innan den kan anses vara "verklig". Klienten kan visa ändringen omedelbart, men måste vara beredd att synkronisera den när servern svarar.

---

## Steg 1 — HTTP: Ladda loggboken när sidan öppnas

Innan du öppnar en WebSocket connection, hämta det aktuella dokumentets tillstånd via följande REST-endpoint.

**GET** `/api/journal?childId=42&date=2026-04-22` (om ni lämnar datumet tomt får ni automatiskt dagens datum)

### Svar
```json
{
  "content": "Emma hade en bra dag...",
  "serverRevision": 7
}
```

Spara sedan båda värdena lokalt:

```js
let content = response.content;
let serverRevision = response.serverRevision;  // Här lagras vilken revision av texten du har
```

## Steg 2 — Anslut till WebSocket

Anslut sedan till WebSocket-endpointen och skicka med JWT som en query-parameter som vi gjort sen innan:
`ws://your-host/ws?token=<jwt>`
När du är ansluten, prenumerera på rummet för loggboken. Formatet för rumsnamnet är:
`journal:{childId}:{date}`
dvs:
```json
{ "type": "subscribe", "room": "journal:42:2026-04-22" }
```
När du byter journal eller lämnar sidan bör du avsluta prenumerationen:
```json
{ "type": "unsubscribe", "room": "journal:42:2026-04-22" }
```

## Steg 3 — Skicka en operation

Varje tangenttryckning (eller en samling tryckningar) skapar en operation. Det finns bara två typer:

| Type | Obligatoriska fält |
| --- | --- |
| INSERT | `position`, `text` |
| DELETE | `position`, `length` |

Position är ett nollbaserat index i textsträngen.
Exempel på hur det kan se ut:
#### Insert
```json
{
  "type" : "DOC_OPERATION",
  "room" : "journal:42:2026-04-22",
  "clientRevision" : 7,
  "operation" : {
    "type" : "INSERT",
    "position" : 23,
    "text" : "x",
  },
  "sequence" : 1
}
```
#### Delete
```json
{
  "type" : "DOC_OPERATION",
  "room" : "journal:42:2026-04-22",
  "clientRevision" : 7,
  "operation" : {
    "type" : "DELETE",
    "position" : 23,
    "length" : 4,
  },
  "sequence" : 2
}
```
> [!IMPORTANT]
> `clientRevision` måste vara den senaste `serverRevision` du tog emot. Alltså inte någon lokal räknande du hanterar själv.

## Steg 4 — Ta emot en broadcast
Varje operation (inklusive din egen) kommer tillbaka som en broadcast efter att servern har transformerat och applicerat den. Detta är avsiktligt: den returnerade operationen är den version som servern har fastställt.

```json
{
  "type" : "DOC_OPERATION",
  "operation" : {
    "type" :  "INSERT",
    "position" : 25,
    "text" : "x",
    "length" : 0
  },
  "serverRevision" : 8,
  "userId" : 1,
  "sequence" : 3
}
```

När du tar emot detta meddelande måste du:
- Kontrollera om det är din egen operation (se "[in-flight buffer](#steg-5---in-flight-buffer)" nedan).
- Applicera operationen på den lokala journalen.
- Uppdatera `serverRevision` till det värdet i meddelandet.

## Steg 5 — In-flight buffer
Detta är klientsidan av OT. Utan denna kommer texten hoppa runt när två personer skriver samtidigt.

**Problemet**: Medan din operation är "in-flight" (skickad men inte bekräftad), kan servern skicka någon annans ändring. Du kan inte applicera den direkt eftersom ditt lokala tillstånd redan innehåller din obekräftade ändring, vilket serverns tillstånd inte gör än.

**Lösning**: Alla inkommande operationer från servern måste transformeras mot alla operationer som för tillfället ligger i din `in-flight buffer` innan de appliceras lokalt.

**Exempel på logik med psuedokod**
```js
let globalSequence = 0       // global counter som håller koll på antalet operationer du har skickat
let serverRevision  = 0;       // Senaste revision från servern
let inFlight: Op[]  = [];         // Skickade men ej bekräftade ops

function onMessage(msg: BroadcastMessage) {
  let incoming = msg.operation;

  if (isMyOwnAck(msg)) {
    // Servern bekräftade vår äldsta väntande op.
    inFlight.shift();
  } else {
    // Någon annans ändring kom in. Transformera den mot vår kö.
    for (const myOp of inFlight) {
      incoming = transformClient(incoming, myOp);
    }
    applyToLocalContent(incoming);
  }
  serverRevision = msg.serverRevision;
}
```
För att se hur `transformClient` kan implementeras kan ni ta en titt på min implementering av transformations i `mistral/backend/src/main/java/se/mistral/backend/journal/ot/OperationTransformer.java`. Jag har skrivit många kommentarer för att göra det enkelt att förstå tankesättet. Likaså har jag implementeringen för att applicera operationer på texten i `mistral/backend/src/main/java/se/mistral/backend/journal/JournalService.java:37`.

För att kunna ha koll på om det är er ändring ni får in eller inte, så skickar ni med er `globalSequence` per operation och använder denna samt `userId` i responsen för att se om det var en av era egna operationer.

**Pseudokod för `isMyOwnAck(msg)`:**
```js
function isMyOwnAck(msg) {
  // Vi kollar om avsändaren är jag, OCH om sekvensnumret 
  // matchar det äldsta vi väntar på i vår kö.
  return msg.userId === myUserId && inFlight.length > 0 && msg.sequence === inFlight[0].sequence;
}
```