### PR TITLE
Revised transformational actions on textarea

### DIFF
--- a/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.html
+++ b/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.html
@@ -1,7 +1,7 @@
 <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start">
   <mat-tab label="Dagsrapport">
     <mat-form-field>
-      <textarea matInput [ngModel]="text()" (input)="onInput($event)"></textarea>
+      <textarea #journalContent matInput [ngModel]="text()" (input)="onInput($event)"></textarea>
     </mat-form-field>
 
   </mat-tab>

--- a/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.ts
+++ b/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, signal, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, signal, Input, OnChanges, SimpleChanges, inject, viewChild, ElementRef } from '@angular/core';
 import { MatFormField } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatTabGroup, MatTab } from "@angular/material/tabs";
@@ -23,6 +23,7 @@ export class MainLiveJournal implements OnInit, OnChanges, OnDestroy {
   private differ = new textDiff();
   private operationalTransformer = new operationalTransformation();
   private journalService = inject(JournalService);
+  private textArea = viewChild.required<ElementRef<HTMLTextAreaElement>>("journalContent");
 
   text = signal('');
   prevText = '';
@@ -58,14 +59,16 @@ export class MainLiveJournal implements OnInit, OnChanges, OnDestroy {
   }
 
   applyToLocalContent(incoming: WsJournalWriteOperation): void {
-    const text: string = this.text();
+    //const text: string = this.text();
     const pos: number = incoming.position;
     switch(incoming.type) {
       case 'INSERT':
-        this.text.set(text.slice(0, pos) + incoming.text + text.slice(pos, text.length));
+        //this.text.set(text.slice(0, pos) + incoming.text + text.slice(pos, text.length));
+        this.textArea().nativeElement.setRangeText(incoming.text, pos, pos, "preserve");
         break;
       case 'DELETE':
-        this.text.set(text.slice(0, pos) + text.slice(pos + 1, text.length));
+        //this.text.set(text.slice(0, pos) + text.slice(pos + 1, text.length));
+        this.textArea().nativeElement.setRangeText("", pos, pos + 1, "preserve");
         break;
     }
   }


### PR DESCRIPTION
Istället för att manipulera signalen som är bunden till textarean, så har jag helt enkelt ändrat till att direkt manipulera textarean. Eftersom textarean är tvåvägsbunden till signalen så hålls signalen uppdaterad ändå.

```js
private textArea = viewChild.required<ElementRef<HTMLTextAreaElement>>("journalContent");

applyToLocalContent(incoming: WsJournalWriteOperation): void {
    //const text: string = this.text();
    const pos: number = incoming.position;
    switch(incoming.type) {
      case 'INSERT':
        //this.text.set(text.slice(0, pos) + incoming.text + text.slice(pos, text.length));
        this.textArea().nativeElement.setRangeText(incoming.text, pos, pos, "preserve");
        break;
      case 'DELETE':
        //this.text.set(text.slice(0, pos) + text.slice(pos + 1, text.length));
        this.textArea().nativeElement.setRangeText("", pos, pos + 1, "preserve");
        break;
    }
}
```