### PR TITLE
sync text signal after remote op

### DIFF
--- a/backend/src/main/java/se/mistral/backend/child/ChildController.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildController.java
@@ -22,7 +22,7 @@ public class ChildController {
 
     private final ChildService childService;
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<List<ChildResponse>> getAllChildren() {
         return ResponseEntity.ok(childService.getAllChildren());
     }

--- a/frontend/src/app/core/utils/date-utils.ts
+++ b/frontend/src/app/core/utils/date-utils.ts
@@ -1,0 +1,4 @@
+export function localDateToday(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+}

--- a/frontend/src/app/routes/main-page/attendance-box/attendance-box.ts
+++ b/frontend/src/app/routes/main-page/attendance-box/attendance-box.ts
@@ -6,7 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ConfirmationDialog } from '../confirmation-dialog/confirmation-dialog';
 import { firstValueFrom } from 'rxjs';
 import { WsAttendanceMessage } from '../../../core/websocket/websocket.service';
-
+import { localDateToday } from '../../../core/utils/date-utils';
 
 @Component({
   selector: 'attendance-box',
@@ -20,12 +20,8 @@ export class AttendanceBox {
   errorMessage = '';
   dialog = inject(MatDialog);
 
-  get dateStr() {
-    return new Date().toISOString().split('T')[0];
-  }
-
   get isChecked(): boolean {
-    return this.attendanceService.getSignal(this.childSignal().id, this.dateStr)() ?? false;
+    return this.attendanceService.getSignal(this.childSignal().id, localDateToday())() ?? false;
   }
 
   private attendanceService = inject(AttendanceService);
@@ -35,7 +31,7 @@ export class AttendanceBox {
       const child = this.childSignal();
       if (!child) return;
 
-      const sig = this.attendanceService.getSignal(child.id, this.dateStr);
+      const sig = this.attendanceService.getSignal(child.id, localDateToday());
       if (sig() === null) {
         if (child.present === null) {
           sig.set(false);
@@ -60,10 +56,10 @@ export class AttendanceBox {
       }
     }
 
-    const sig = this.attendanceService.getSignal(this.childSignal().id, this.dateStr);
+    const sig = this.attendanceService.getSignal(this.childSignal().id, localDateToday());
     sig.set(newStatus);
 
-    this.attendanceService.setAttendance(this.childSignal().id, this.dateStr, newStatus).subscribe({
+    this.attendanceService.setAttendance(this.childSignal().id, localDateToday(), newStatus).subscribe({
       next: (data) => sig.set(data.present),
       error: (err) => {
         console.error('Kunde inte spara', err);

--- a/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
+++ b/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
@@ -9,6 +9,7 @@ import { WsAttendanceMessage } from '../../../core/websocket/websocket.service';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
+import { localDateToday } from '../../../core/utils/date-utils';
 
 @Component({
   selector: 'main-child-list',
@@ -35,12 +36,8 @@ export class ChildList implements OnInit {
     this.searchQuery.set(sq);
   }
 
-  get dateStr() {
-    return new Date().toISOString().split('T')[0];
-  }
-
   get isChecked(): boolean {
-    return this.attendanceService.getSignal(this.childSignal().id, this.dateStr)() ?? false;
+    return this.attendanceService.getSignal(this.childSignal().id, localDateToday())() ?? false;
   }
 
   ngOnInit() {
@@ -73,7 +70,7 @@ export class ChildList implements OnInit {
       return;
     }
 
-    const sig = this.attendanceService.getSignal(targetChild.id, this.dateStr);
+    const sig = this.attendanceService.getSignal(targetChild.id, localDateToday());
     sig.set(message.present);
   }
 }

--- a/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.ts
+++ b/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.ts
@@ -93,6 +93,9 @@ export class MainLiveJournal implements OnInit, OnChanges, OnDestroy {
         this.textArea().nativeElement.setRangeText("", pos, pos + 1, "preserve");
         break;
     }
+
+    this.text.set(this.textArea().nativeElement.value);
+    this.prevText = this.text();
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.ts
+++ b/frontend/src/app/routes/main-page/main-live-journal/main-live-journal.ts
@@ -9,6 +9,7 @@ import { textDiff, Diff } from './text-diff';
 import { operationalTransformation } from './operational-transformation';
 import { JournalService } from '../../../core/journal/journal.service';
 import { environment } from '../../../../environments/environment';
+import { localDateToday } from '../../../core/utils/date-utils';
 
 @Component({
   selector: 'main-live-journal',
@@ -58,9 +59,9 @@ export class MainLiveJournal implements OnInit, OnChanges, OnDestroy {
 
   getRoom(): string {
     if (this.child.id != 0) {
-      return 'journal:child:' + this.child.id + ':' + new Date().toISOString().split('T')[0];
+      return 'journal:child:' + this.child.id + ':' + localDateToday();
     } else {
-      return 'journal:group:' + 1 + ':' + new Date().toISOString().split('T')[0];
+      return 'journal:group:' + 1 + ':' + localDateToday();
     }
   }
 


### PR DESCRIPTION
Utifrån mina tester ska det här lösa dem felen vi hade igår med duplicerade operationer och liknande problem. Det hade att göra med att signalen som användes för att räkna ut diffen inte uppdaterades när en operation kom in från servern. Ytterligare ändrade jag så att vi använder lokal tid i stället för UTC när vi hämtar date