### PR TITLE
Feature/colored users

### DIFF
--- a/backend/src/main/java/se/mistral/backend/admin/AdminService.java
+++ b/backend/src/main/java/se/mistral/backend/admin/AdminService.java
@@ -39,7 +39,7 @@ public class AdminService {
         User user = userRepository.findById(id).orElseThrow(() -> new NotFoundException("User not found"));
         user.setActive(true);
         User saved = userRepository.save(user);
-        return new UserResponse(saved.getId(), saved.getName(), saved.getRole(), saved.getEmail());
+        return new UserResponse(saved.getId(), saved.getName(), saved.getRole(), saved.getEmail(), saved.getColor());
     }
 
     /**

--- a/backend/src/main/java/se/mistral/backend/auth/AuthService.java
+++ b/backend/src/main/java/se/mistral/backend/auth/AuthService.java
@@ -1,6 +1,9 @@
 package se.mistral.backend.auth;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.Random;
+
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -25,6 +28,8 @@ public class AuthService {
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
 
+    private static final Random RANDOM = new Random();
+
     /**
      * Register a new user.
      *
@@ -41,6 +46,7 @@ public class AuthService {
             .email(request.email())
             .password(passwordEncoder.encode(request.password()))
             .role(Role.TEACHER)
+            .color(randomColor())
             .build();
         userRepository.save(user);
         
@@ -57,5 +63,13 @@ public class AuthService {
         User user = userRepository.findByEmail(request.email())
             .orElseThrow(() -> new NotFoundException("User not found"));
         return new AuthResponse(jwtService.generateToken(user), user.getId());
+    }
+
+    /**
+     * Generates a random HEX color string
+     * @return the color as a String
+     */
+    private String randomColor() {
+        return String.format("#%06X", RANDOM.nextInt(0x1000000));
     }
 }

--- a/backend/src/main/java/se/mistral/backend/user/Role.java
+++ b/backend/src/main/java/se/mistral/backend/user/Role.java
@@ -5,4 +5,3 @@ public enum Role {
     PARENT,
     ADMIN
 }
-

--- a/backend/src/main/java/se/mistral/backend/user/User.java
+++ b/backend/src/main/java/se/mistral/backend/user/User.java
@@ -55,7 +55,7 @@ public class User implements UserDetails {
 
     @Column(nullable = false)
     @Builder.Default
-    private String color = "#808080";
+    private String color = "#0b8de3";
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/backend/src/main/java/se/mistral/backend/user/User.java
+++ b/backend/src/main/java/se/mistral/backend/user/User.java
@@ -53,6 +53,10 @@ public class User implements UserDetails {
     @Builder.Default
     private boolean active = false;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private String color = "#808080";
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));

--- a/backend/src/main/java/se/mistral/backend/user/UserController.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserController.java
@@ -2,11 +2,17 @@ package se.mistral.backend.user;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
 import se.mistral.backend.user.dto.BasicUserInformation;
+import se.mistral.backend.user.dto.UpdateColorRequest;
 import se.mistral.backend.user.dto.UserResponse;
 
 import java.util.List;
@@ -32,6 +38,14 @@ public class UserController {
     @GetMapping("/teacher")
     public ResponseEntity<UserResponse> retrieveOneTeacher(@RequestParam Long teacherId) {
         return ResponseEntity.ok(userService.retrieveOneTeacher(teacherId));
+    }
+
+    @PatchMapping("/color")
+    public ResponseEntity<Void> updateColor(
+            @AuthenticationPrincipal User user,
+            @Valid @RequestBody UpdateColorRequest request) {
+        userService.updateColor(user.getId(), request.color());
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/backend/src/main/java/se/mistral/backend/user/UserController.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserController.java
@@ -17,7 +17,6 @@ import se.mistral.backend.user.dto.UserResponse;
 
 import java.util.List;
 
-
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor

--- a/backend/src/main/java/se/mistral/backend/user/UserRepository.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserRepository.java
@@ -1,7 +1,6 @@
 package se.mistral.backend.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import se.mistral.backend.user.dto.BasicUserInformation;
 import se.mistral.backend.user.dto.UserResponse;
@@ -27,12 +26,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     /**
-     * Find user by role teacher.
+     * Find user by role.
      *
-     * @return the list of all teachers
+     * @param role the role to filter by
+     * @return the list of users with a given role
      */
-    @Query("SELECT new se.mistral.backend.user.dto.BasicUserInformation(user.id, user.name, user.color) " +
-           "FROM User user WHERE user.role = TEACHER")
-    List<BasicUserInformation> findUserByRole_Teacher();
+    List<BasicUserInformation> findUserByRole(Role role);
     UserResponse findUserById(Long id);
 }

--- a/backend/src/main/java/se/mistral/backend/user/UserRepository.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserRepository.java
@@ -31,7 +31,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
      *
      * @return the list of all teachers
      */
-    @Query("SELECT new se.mistral.backend.user.dto.BasicUserInformation(user.id, user.name) " +
+    @Query("SELECT new se.mistral.backend.user.dto.BasicUserInformation(user.id, user.name, user.color) " +
            "FROM User user WHERE user.role = TEACHER")
     List<BasicUserInformation> findUserByRole_Teacher();
     UserResponse findUserById(Long id);

--- a/backend/src/main/java/se/mistral/backend/user/UserRepository.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserRepository.java
@@ -32,5 +32,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * @return the list of users with a given role
      */
     List<BasicUserInformation> findUserByRole(Role role);
+
     UserResponse findUserById(Long id);
 }

--- a/backend/src/main/java/se/mistral/backend/user/UserService.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserService.java
@@ -43,11 +43,11 @@ public class UserService {
      * Update a users color
      *
      * @param userid the user's id
-     * @param color the new color
+     * @param color  the new color
      */
     public void updateColor(Long userId, String color) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new NotFoundException("User not found"));
+                .orElseThrow(() -> new NotFoundException("User not found"));
         user.setColor(color);
         userRepository.save(user);
     }

--- a/backend/src/main/java/se/mistral/backend/user/UserService.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
      * @return the list of all teachers.
      */
     public List<BasicUserInformation> retrieveAllTeachers() {
-        return userRepository.findUserByRole_Teacher();
+        return userRepository.findUserByRole(Role.TEACHER);
     }
 
     public UserResponse retrieveOneTeacher(Long teacherId) {

--- a/backend/src/main/java/se/mistral/backend/user/UserService.java
+++ b/backend/src/main/java/se/mistral/backend/user/UserService.java
@@ -2,6 +2,8 @@ package se.mistral.backend.user;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import se.mistral.backend.exception.NotFoundException;
 import se.mistral.backend.user.dto.BasicUserInformation;
 import se.mistral.backend.user.dto.UserResponse;
 
@@ -35,5 +37,18 @@ public class UserService {
 
     public UserResponse retrieveOneTeacher(Long teacherId) {
         return userRepository.findUserById(teacherId);
+    }
+
+    /**
+     * Update a users color
+     *
+     * @param userid the user's id
+     * @param color the new color
+     */
+    public void updateColor(Long userId, String color) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException("User not found"));
+        user.setColor(color);
+        userRepository.save(user);
     }
 }

--- a/backend/src/main/java/se/mistral/backend/user/dto/BasicUserInformation.java
+++ b/backend/src/main/java/se/mistral/backend/user/dto/BasicUserInformation.java
@@ -1,7 +1,7 @@
 package se.mistral.backend.user.dto;
 
 public record BasicUserInformation(
-    Long id,
-    String name,
-    String color
-) { }
+        Long id,
+        String name,
+        String color) {
+}

--- a/backend/src/main/java/se/mistral/backend/user/dto/BasicUserInformation.java
+++ b/backend/src/main/java/se/mistral/backend/user/dto/BasicUserInformation.java
@@ -1,6 +1,7 @@
 package se.mistral.backend.user.dto;
 
 public record BasicUserInformation(
-        Long id,
-        String name
+    Long id,
+    String name,
+    String color
 ) { }

--- a/backend/src/main/java/se/mistral/backend/user/dto/UpdateColorRequest.java
+++ b/backend/src/main/java/se/mistral/backend/user/dto/UpdateColorRequest.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record UpdateColorRequest(
-    @NotBlank @Pattern(regexp = "^#[0-9A-Fa-f]{6}$") String color
-) { }
+        @NotBlank @Pattern(regexp = "^#[0-9A-Fa-f]{6}$") String color) {
+}

--- a/backend/src/main/java/se/mistral/backend/user/dto/UpdateColorRequest.java
+++ b/backend/src/main/java/se/mistral/backend/user/dto/UpdateColorRequest.java
@@ -1,0 +1,8 @@
+package se.mistral.backend.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateColorRequest(
+    @NotBlank @Pattern(regexp = "^#[0-9A-Fa-f]{6}$") String color
+) { }

--- a/backend/src/main/java/se/mistral/backend/user/dto/UserResponse.java
+++ b/backend/src/main/java/se/mistral/backend/user/dto/UserResponse.java
@@ -1,10 +1,11 @@
 package se.mistral.backend.user.dto;
+
 import se.mistral.backend.user.Role;
 
 public record UserResponse(
-    Long id,
-    String name,
-    Role role,
-    String email,
-    String color
-) { }
+        Long id,
+        String name,
+        Role role,
+        String email,
+        String color) {
+}

--- a/backend/src/main/java/se/mistral/backend/user/dto/UserResponse.java
+++ b/backend/src/main/java/se/mistral/backend/user/dto/UserResponse.java
@@ -5,5 +5,6 @@ public record UserResponse(
     Long id,
     String name,
     Role role,
-    String email
+    String email,
+    String color
 ) { }

--- a/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
+++ b/backend/src/main/java/se/mistral/backend/websocket/MyWebSocketHandler.java
@@ -90,6 +90,7 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
 
             session.getAttributes().put("userId", user.getId());
             session.getAttributes().put("userName", user.getName());
+            session.getAttributes().put("userColor", user.getColor());
             sessionToRooms.putIfAbsent(session, ConcurrentHashMap.newKeySet());
 
             List<PresenceUser> allPresent = roomPresence.values().stream()
@@ -248,9 +249,10 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
 
         if (room instanceof Journal) {
             String name = (String) session.getAttributes().get("userName");
+            String color = (String) session.getAttributes().get("userColor");
             roomPresence.computeIfAbsent(key, k -> new ConcurrentHashMap<>())
-                .put(userId, new PresenceUser(userId, name, key));
-            broadcastToAll(toTextMessage(new PresenceMessage("PRESENCE_JOIN", key, userId, name)));
+                .put(userId, new PresenceUser(userId, name, key, color));
+            broadcastToAll(toTextMessage(new PresenceMessage("PRESENCE_JOIN", key, userId, name, color)));
         }
     }
 
@@ -295,12 +297,13 @@ public class MyWebSocketHandler extends TextWebSocketHandler {
 
         Long userId = (Long) session.getAttributes().get("userId");
         String name = (String) session.getAttributes().get("userName");
+        String color = (String) session.getAttributes().get("userColor");
 
         roomPresence.computeIfPresent(roomKey, (k, presence) -> {
             presence.remove(userId);
             return presence.isEmpty() ? null : presence;
         });
 
-        broadcastToAll(toTextMessage(new PresenceMessage("PRESENCE_LEAVE", roomKey, userId, name)));
+        broadcastToAll(toTextMessage(new PresenceMessage("PRESENCE_LEAVE", roomKey, userId, name, color)));
     }
 }

--- a/backend/src/main/java/se/mistral/backend/websocket/dto/PresenceMessage.java
+++ b/backend/src/main/java/se/mistral/backend/websocket/dto/PresenceMessage.java
@@ -4,5 +4,6 @@ public record PresenceMessage(
     String type,        // "PRESENCE_JOIN" or "PRESENCE_LEAVE"
     String room,
     Long userId,
-    String name
+    String name,
+    String color
 ) { }

--- a/backend/src/main/java/se/mistral/backend/websocket/dto/PresenceUser.java
+++ b/backend/src/main/java/se/mistral/backend/websocket/dto/PresenceUser.java
@@ -1,4 +1,4 @@
 package se.mistral.backend.websocket.dto;
 
-public record PresenceUser(Long userId, String name, String room) { }
+public record PresenceUser(Long userId, String name, String room, String color) { }
 

--- a/backend/src/main/resources/db/migration/V18__add_color_to_user_table.sql
+++ b/backend/src/main/resources/db/migration/V18__add_color_to_user_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN color VARCHAR(7) NOT NULL DEFAULT '#0b8de3' -- default=någon blå färg

--- a/backend/src/test/java/se/mistral/backend/UserTests.java
+++ b/backend/src/test/java/se/mistral/backend/UserTests.java
@@ -24,7 +24,6 @@ public class UserTests {
     @Autowired
     private AuthService authService;
 
-
     @Test
     void retrieveAllTeachersNoTeacherTest() {
         assertThat(userService.retrieveAllTeachers().isEmpty());
@@ -41,7 +40,8 @@ public class UserTests {
         assertThat(user1.isPresent());
 
         assertThat(userService.retrieveAllTeachers().size()).isEqualTo(1);
-        assertThat(userService.retrieveAllTeachers().getFirst()).isEqualTo(new BasicUserInformation(user1.get().getId(), user1.get().getName()));
+        assertThat(userService.retrieveAllTeachers().getFirst()).isEqualTo(
+                new BasicUserInformation(user1.get().getId(), user1.get().getName(), user1.get().getColor()));
     }
 
     @Test
@@ -64,8 +64,10 @@ public class UserTests {
         assertThat(user1.isPresent());
         assertThat(user2.isPresent());
 
-        assertThat(userService.retrieveAllTeachers().getFirst()).isEqualTo(new BasicUserInformation(user1.get().getId(), user1.get().getName()));
-        assertThat(userService.retrieveAllTeachers().getLast()).isEqualTo(new BasicUserInformation(user2.get().getId(), user2.get().getName()));
+        assertThat(userService.retrieveAllTeachers().getFirst())
+                .isEqualTo(new BasicUserInformation(user1.get().getId(), user1.get().getName(), user1.get().getColor()));
+        assertThat(userService.retrieveAllTeachers().getLast())
+                .isEqualTo(new BasicUserInformation(user2.get().getId(), user2.get().getName(), user2.get().getColor()));
     }
 
     @Test
@@ -132,8 +134,11 @@ public class UserTests {
         assertThat(user5.isPresent());
         assertThat(user10.isPresent());
 
-        assertThat(userService.retrieveAllTeachers().getFirst()).isEqualTo(new BasicUserInformation(user1.get().getId(), user1.get().getName()));
-        assertThat(userService.retrieveAllTeachers().contains(new BasicUserInformation(user5.get().getId(), user5.get().getName())));
-        assertThat(userService.retrieveAllTeachers().getLast()).isEqualTo(new BasicUserInformation(user10.get().getId(), user10.get().getName()));
+        assertThat(userService.retrieveAllTeachers().getFirst())
+                .isEqualTo(new BasicUserInformation(user1.get().getId(), user1.get().getName(), user1.get().getColor()));
+        assertThat(userService.retrieveAllTeachers()
+                .contains(new BasicUserInformation(user5.get().getId(), user5.get().getName(), user5.get().getColor())));
+        assertThat(userService.retrieveAllTeachers().getLast())
+                .isEqualTo(new BasicUserInformation(user10.get().getId(), user10.get().getName(), user10.get().getColor()));
     }
 }


### PR DESCRIPTION
Man får numera med användarens färg i `BasicUserInformation` och `UserResponse` som skickas i samband med requests mot `api/auth/login`, `api/user/*` och `api/admin/user/{id}`. Färgen kommer också skickas genom `PRESENCE_LEAVE`-, `PRESENCE_JOIN`- och `PRESENCE_STATE`-meddelanden i WebSocket-endpointen. Färgen kan uppdateras med ett `PATCH`-request till `api/user/color`. Allt som krävs här är att man anger färgen i request-bodyn.

Exempel:
```json
{
    "color" : "#0623Fg"
}
```

Success indikeras med koden 204 i responsen.