### PR TITLE
Update/attendance

### DIFF
--- a/backend/src/main/java/se/mistral/backend/attendance/Attendance.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/Attendance.java
@@ -12,6 +12,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 
 import lombok.Data;
 import lombok.Builder;
@@ -19,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -34,8 +37,13 @@ public class Attendance {
     @Column(nullable = false)
     private LocalDate date;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Boolean present;
+    private AttendanceStatus status = AttendanceStatus.NOT_SET;
+
+    private LocalDateTime checkInTime;
+    private LocalDateTime checkOutTime;
 
     @Version
     private int version;

--- a/backend/src/main/java/se/mistral/backend/attendance/Attendance.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/Attendance.java
@@ -12,8 +12,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.EnumType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import lombok.Data;
 import lombok.Builder;
@@ -38,7 +38,7 @@ public class Attendance {
     private LocalDate date;
 
     @Builder.Default
-    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(nullable = false)
     private AttendanceStatus status = AttendanceStatus.NOT_SET;
 

--- a/backend/src/main/java/se/mistral/backend/attendance/Attendance.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/Attendance.java
@@ -12,8 +12,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.JoinColumn;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 
 import lombok.Data;
 import lombok.Builder;
@@ -38,7 +38,7 @@ public class Attendance {
     private LocalDate date;
 
     @Builder.Default
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AttendanceStatus status = AttendanceStatus.NOT_SET;
 

--- a/backend/src/main/java/se/mistral/backend/attendance/AttendanceController.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/AttendanceController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,5 +44,16 @@ public class AttendanceController {
     @GetMapping()
     public ResponseEntity<AttendanceDto> getAttendance(@RequestParam Long childId, @RequestParam(required = false) LocalDate date) {
         return ResponseEntity.ok(attendanceService.getAttendance(childId, date != null ? date : LocalDate.now()));
+    }
+
+    /**
+     * Gets attendance history for a child.
+     *
+     * @param childId the child id
+     * @return the full attendance history ordered by date descending
+     */
+    @GetMapping("/history")
+    public ResponseEntity<List<AttendanceDto>> getAttendanceHistory(@RequestParam Long childId) {
+        return ResponseEntity.ok(attendanceService.getAttendanceHistory(childId));
     }
 }

--- a/backend/src/main/java/se/mistral/backend/attendance/AttendanceRepository.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/AttendanceRepository.java
@@ -1,23 +1,28 @@
 package se.mistral.backend.attendance;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import se.mistral.backend.attendance.dto.AttendanceDto;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     /**
-     * Find presence by child id and date.
+     * Find attendance by child id and date.
      *
      * @param childId the child id
      * @param date    the date
-     * @return the presence status of the child as an Attendance dto
+     * @return the attendance dto of the child on the given date
      */
-    Optional<AttendanceDto> findPresenceByChildIdAndDate(Long childId, LocalDate date);
+    @Query("SELECT new se.mistral.backend.attendance.dto.AttendanceDto(a.status, a.checkInTime, a.checkOutTime) " +
+            "FROM Attendance a WHERE a.child.id = :childId AND a.date = :date")
+    Optional<AttendanceDto> findAttendanceByChildIdAndDate(@Param("childId") Long childId, @Param("date") LocalDate date);
 
     /**
      * Find by child id and date .
@@ -27,4 +32,14 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
      * @return the presence status of the child an Attendance entity
      */
     Optional<Attendance> findByChildIdAndDate(Long childId, LocalDate date);
+
+    /**
+     * Find all attendance records for a child, ordered by date descending.
+     *
+     * @param childId the child id
+     * @return the attendance history of the child
+     */
+    @Query("SELECT new se.mistral.backend.attendance.dto.AttendanceDto(a.status, a.checkInTime, a.checkOutTime) " +
+            "FROM Attendance a WHERE a.child.id = :childId ORDER BY a.date DESC")
+    List<AttendanceDto> findAttendanceHistoryByChildId(@Param("childId") Long childId);
 }

--- a/backend/src/main/java/se/mistral/backend/attendance/AttendanceService.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/AttendanceService.java
@@ -9,6 +9,8 @@ import se.mistral.backend.child.ChildRepository;
 import se.mistral.backend.attendance.dto.AttendanceDto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 
 @Service
@@ -26,8 +28,21 @@ public class AttendanceService {
      * @return the attendance dto of the child at the given date
      */
     public AttendanceDto getAttendance(Long childId, LocalDate date) {
-        return attendanceRepository.findPresenceByChildIdAndDate(childId, date)
+        return attendanceRepository.findAttendanceByChildIdAndDate(childId, date)
         .orElseThrow(() -> new NotFoundException("Attendance is not logged for this child on " + date.toString()));
+    }
+
+    /**
+     * Gets the full attendance history for a child, ordered by date descending.
+     *
+     * @param childId the child id
+     * @return the list of attendance dtos for the child
+     */
+    public List<AttendanceDto> getAttendanceHistory(Long childId) {
+        if (!childRepository.existsById(childId)) {
+            throw new NotFoundException("Child not found");
+        }
+        return attendanceRepository.findAttendanceHistoryByChildId(childId);
     }
 
     /**
@@ -41,12 +56,18 @@ public class AttendanceService {
             .orElseGet(() -> Attendance.builder()
                 .date(request.date())
                 .child(childRepository.findById(request.childId()).orElseThrow(() -> new NotFoundException("Child not found")))
-                .present(request.present())
                 .build()
             );
-        attendance.setPresent(request.present());
+
+        attendance.setStatus(request.status());
+
+        if (request.status() == AttendanceStatus.CHECKED_IN) {
+            attendance.setCheckInTime(LocalDateTime.now());
+        } else if (request.status() == AttendanceStatus.CHECKED_OUT) {
+            attendance.setCheckOutTime(LocalDateTime.now());
+        }
+
         attendance = attendanceRepository.save(attendance);      // throws ObjectOptimisticLockingFailureException on conflict
-        return new AttendanceDto(attendance.getPresent());
+        return new AttendanceDto(attendance.getStatus(), attendance.getCheckInTime(), attendance.getCheckOutTime());
     }
 }
-

--- a/backend/src/main/java/se/mistral/backend/attendance/AttendanceStatus.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/AttendanceStatus.java
@@ -1,0 +1,9 @@
+package se.mistral.backend.attendance;
+
+public enum AttendanceStatus {
+    NOT_SET,
+    CHECKED_IN,
+    CHECKED_OUT,
+    LEAVE,
+    ABSENT
+}

--- a/backend/src/main/java/se/mistral/backend/attendance/dto/AttendanceDto.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/dto/AttendanceDto.java
@@ -8,4 +8,4 @@ public record AttendanceDto(
     AttendanceStatus status,
     LocalDateTime checkInTime,
     LocalDateTime checkOutTime
-) {}
+) { }

--- a/backend/src/main/java/se/mistral/backend/attendance/dto/AttendanceDto.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/dto/AttendanceDto.java
@@ -1,4 +1,11 @@
 package se.mistral.backend.attendance.dto;
 
-public record AttendanceDto(Boolean present) {
-}
+import se.mistral.backend.attendance.AttendanceStatus;
+
+import java.time.LocalDateTime;
+
+public record AttendanceDto(
+    AttendanceStatus status,
+    LocalDateTime checkInTime,
+    LocalDateTime checkOutTime
+) {}

--- a/backend/src/main/java/se/mistral/backend/attendance/dto/AttendanceRequest.java
+++ b/backend/src/main/java/se/mistral/backend/attendance/dto/AttendanceRequest.java
@@ -1,6 +1,9 @@
 package se.mistral.backend.attendance.dto;
 
+import jakarta.validation.constraints.NotNull;
+import se.mistral.backend.attendance.AttendanceStatus;
+
 import java.time.LocalDate;
 
-public record AttendanceRequest(Long childId, LocalDate date, Boolean present) {
+public record AttendanceRequest(Long childId, LocalDate date, @NotNull AttendanceStatus status) {
 }

--- a/backend/src/main/java/se/mistral/backend/child/ChildRepository.java
+++ b/backend/src/main/java/se/mistral/backend/child/ChildRepository.java
@@ -22,7 +22,7 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
      * @param date the date
      * @return the list of children registered on the date.
      */
-    @Query("SELECT new se.mistral.backend.child.dto.AttendanceResponse(c.id, c.name, a.date, a.present) " +
+    @Query("SELECT new se.mistral.backend.child.dto.AttendanceResponse(c.id, c.name, a.date, a.status) " +
             "FROM Child c LEFT JOIN Attendance a ON a.child.id = c.id AND a.date = :date")
     List<AttendanceResponse> findAllChildrenWithAttendanceIfExists(@Param("date") LocalDate date);
 
@@ -33,7 +33,7 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
      * @param groupId the group id
      * @return the list of children registered on the date in the group.
      */
-    @Query("SELECT new se.mistral.backend.child.dto.AttendanceResponse(c.id, c.name, a.date, a.present) " +
+    @Query("SELECT new se.mistral.backend.child.dto.AttendanceResponse(c.id, c.name, a.date, a.status) " +
             "FROM Child c LEFT JOIN Attendance a ON a.child.id = c.id AND a.date = :date WHERE c.group.id = :groupId")
     List<AttendanceResponse> findAllChildrenWithAttendanceIfExistsInGroup(@Param("date") LocalDate date, @Param("groupId") Long groupId);
 

--- a/backend/src/main/java/se/mistral/backend/child/dto/AttendanceResponse.java
+++ b/backend/src/main/java/se/mistral/backend/child/dto/AttendanceResponse.java
@@ -1,10 +1,12 @@
 package se.mistral.backend.child.dto;
 
+import se.mistral.backend.attendance.AttendanceStatus;
+
 import java.time.LocalDate;
 
 public record AttendanceResponse(
     Long id,
     String name,
     LocalDate date,
-    Boolean present
+    AttendanceStatus status
 ) { }

--- a/backend/src/main/resources/db/migration/V15__create_attendance_status_type.sql
+++ b/backend/src/main/resources/db/migration/V15__create_attendance_status_type.sql
@@ -1,0 +1,7 @@
+CREATE TYPE attendance_status AS ENUM (
+    'NOT_SET',
+    'CHECKED_IN',
+    'CHECKED_OUT',
+    'LEAVE',
+    'ABSENT'
+);

--- a/backend/src/main/resources/db/migration/V16__replace_present_with_status_in_attendance.sql
+++ b/backend/src/main/resources/db/migration/V16__replace_present_with_status_in_attendance.sql
@@ -1,0 +1,2 @@
+ALTER TABLE attendance DROP COLUMN present;
+ALTER TABLE attendance ADD COLUMN status attendance_status NOT NULL DEFAULT 'NOT_SET';

--- a/backend/src/main/resources/db/migration/V17__add_checkin_checkout_time_to_attendance.sql
+++ b/backend/src/main/resources/db/migration/V17__add_checkin_checkout_time_to_attendance.sql
@@ -1,0 +1,2 @@
+ALTER TABLE attendance ADD COLUMN check_in_time TIMESTAMP;
+ALTER TABLE attendance ADD COLUMN check_out_time TIMESTAMP;

--- a/backend/src/main/resources/db/migration/V19__change_attendance_status_to_varchar.sql
+++ b/backend/src/main/resources/db/migration/V19__change_attendance_status_to_varchar.sql
@@ -1,0 +1,2 @@
+ALTER TABLE attendance ALTER COLUMN status TYPE varchar(50) USING status::text;
+ALTER TABLE attendance ALTER COLUMN status SET DEFAULT 'NOT_SET';

--- a/backend/src/test/java/se/mistral/backend/AttendanceTests.java
+++ b/backend/src/test/java/se/mistral/backend/AttendanceTests.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import se.mistral.backend.attendance.AttendanceService;
+import se.mistral.backend.attendance.AttendanceStatus;
 import se.mistral.backend.attendance.dto.AttendanceDto;
 import se.mistral.backend.attendance.dto.AttendanceRequest;
 import se.mistral.backend.child.ChildService;
@@ -13,6 +14,7 @@ import se.mistral.backend.child.dto.CreateChildRequest;
 import se.mistral.backend.exception.NotFoundException;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -29,63 +31,171 @@ public class AttendanceTests {
 
     LocalDate testDate = LocalDate.of(2026, 4, 1);
 
+    private ChildResponse createTestChild() {
+        return childService.createChild(new CreateChildRequest("test"));
+    }
+
+    // --- getAttendance ---
+
     @Test
     void getAttendanceNotFoundTest() {
         assertThatExceptionOfType(NotFoundException.class).isThrownBy(
-                        () -> attendanceService.getAttendance(1L, LocalDate.parse("2026-04-01")))
+                () -> attendanceService.getAttendance(1L, testDate))
                 .withMessage("Attendance is not logged for this child on 2026-04-01");
     }
 
     @Test
-    void getAttendanceTrueTest() {
-        CreateChildRequest childRequest = new CreateChildRequest("test");
-        ChildResponse childResponse = childService.createChild(childRequest);
+    void getAttendanceCheckedInTest() {
+        ChildResponse child = createTestChild();
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate, AttendanceStatus.CHECKED_IN));
 
-        AttendanceRequest attendanceRequest = new AttendanceRequest(childResponse.id(), testDate, true);
-
-        attendanceService.updateAttendance(attendanceRequest);
-        assertThat(attendanceService.getAttendance(childResponse.id(), testDate)).isEqualTo(new AttendanceDto(true));
+        AttendanceDto result = attendanceService.getAttendance(child.id(), testDate);
+        assertThat(result.status()).isEqualTo(AttendanceStatus.CHECKED_IN);
+        assertThat(result.checkInTime()).isNotNull();
+        assertThat(result.checkOutTime()).isNull();
     }
 
     @Test
-    void getAttendanceFalseTest() {
-        CreateChildRequest childRequest = new CreateChildRequest("test");
-        ChildResponse childResponse = childService.createChild(childRequest);
+    void getAttendanceCheckedOutTest() {
+        ChildResponse child = createTestChild();
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate, AttendanceStatus.CHECKED_OUT));
 
-        AttendanceRequest attendanceRequest = new AttendanceRequest(childResponse.id(), testDate, false);
-
-        attendanceService.updateAttendance(attendanceRequest);
-        assertThat(attendanceService.getAttendance(childResponse.id(), testDate)).isEqualTo(new AttendanceDto(false));
+        AttendanceDto result = attendanceService.getAttendance(child.id(), testDate);
+        assertThat(result.status()).isEqualTo(AttendanceStatus.CHECKED_OUT);
+        assertThat(result.checkOutTime()).isNotNull();
+        assertThat(result.checkInTime()).isNull();
     }
+
+    @Test
+    void getAttendanceAbsentTest() {
+        ChildResponse child = createTestChild();
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate, AttendanceStatus.ABSENT));
+
+        AttendanceDto result = attendanceService.getAttendance(child.id(), testDate);
+        assertThat(result.status()).isEqualTo(AttendanceStatus.ABSENT);
+        assertThat(result.checkInTime()).isNull();
+        assertThat(result.checkOutTime()).isNull();
+    }
+
+    @Test
+    void getAttendanceLeaveTest() {
+        ChildResponse child = createTestChild();
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate, AttendanceStatus.LEAVE));
+
+        AttendanceDto result = attendanceService.getAttendance(child.id(), testDate);
+        assertThat(result.status()).isEqualTo(AttendanceStatus.LEAVE);
+        assertThat(result.checkInTime()).isNull();
+        assertThat(result.checkOutTime()).isNull();
+    }
+
+    // --- updateAttendance ---
 
     @Test
     void updateAttendanceChildNotFoundTest() {
-        AttendanceRequest attendanceRequest = new AttendanceRequest(1L, testDate, true);
+        AttendanceRequest request = new AttendanceRequest(1L, testDate, AttendanceStatus.CHECKED_IN);
         assertThatExceptionOfType(NotFoundException.class).isThrownBy(
-                        () -> attendanceService.updateAttendance(attendanceRequest))
+                () -> attendanceService.updateAttendance(request))
                 .withMessage("Child not found");
-
     }
 
     @Test
-    void updateAttendanceTrueTest() {
-        CreateChildRequest childRequest = new CreateChildRequest("test");
-        ChildResponse childResponse = childService.createChild(childRequest);
+    void updateAttendanceBaseValueDoesNotSetTimesTest() {
+        ChildResponse child = createTestChild();
+        AttendanceDto result = attendanceService.updateAttendance(
+                new AttendanceRequest(child.id(), testDate, AttendanceStatus.NOT_SET));
 
-        AttendanceRequest attendanceRequest = new AttendanceRequest(childResponse.id(), testDate, true);
-
-        AttendanceDto attendanceDto = attendanceService.updateAttendance(attendanceRequest);
-        assertThat(attendanceDto.present());
+        assertThat(result.status()).isEqualTo(AttendanceStatus.NOT_SET);
+        assertThat(result.checkInTime()).isNull();
+        assertThat(result.checkOutTime()).isNull();
     }
 
     @Test
-    void updateAttendanceFalseTest() {
-        CreateChildRequest childRequest = new CreateChildRequest("test");
-        ChildResponse childResponse = childService.createChild(childRequest);
+    void updateAttendanceCheckedInSetsCheckInTimeTest() {
+        ChildResponse child = createTestChild();
+        AttendanceDto result = attendanceService.updateAttendance(
+                new AttendanceRequest(child.id(), testDate, AttendanceStatus.CHECKED_IN));
 
-        AttendanceRequest attendanceRequest = new AttendanceRequest(childResponse.id(), testDate, false);
+        assertThat(result.status()).isEqualTo(AttendanceStatus.CHECKED_IN);
+        assertThat(result.checkInTime()).isNotNull();
+        assertThat(result.checkOutTime()).isNull();
+    }
 
-        AttendanceDto attendanceDto = attendanceService.updateAttendance(attendanceRequest);
-        assertThat(!attendanceDto.present());
+    @Test
+    void updateAttendanceCheckedOutSetsCheckOutTimeTest() {
+        ChildResponse child = createTestChild();
+        AttendanceDto result = attendanceService.updateAttendance(
+                new AttendanceRequest(child.id(), testDate, AttendanceStatus.CHECKED_OUT));
+
+        assertThat(result.status()).isEqualTo(AttendanceStatus.CHECKED_OUT);
+        assertThat(result.checkOutTime()).isNotNull();
+        assertThat(result.checkInTime()).isNull();
+    }
+
+    @Test
+    void updateAttendanceAbsentDoesNotSetTimesTest() {
+        ChildResponse child = createTestChild();
+        AttendanceDto result = attendanceService.updateAttendance(
+                new AttendanceRequest(child.id(), testDate, AttendanceStatus.ABSENT));
+
+        assertThat(result.status()).isEqualTo(AttendanceStatus.ABSENT);
+        assertThat(result.checkInTime()).isNull();
+        assertThat(result.checkOutTime()).isNull();
+    }
+
+    @Test
+    void updateAttendanceLeaveDoesNotSetTimesTest() {
+        ChildResponse child = createTestChild();
+        AttendanceDto result = attendanceService.updateAttendance(
+                new AttendanceRequest(child.id(), testDate, AttendanceStatus.LEAVE));
+
+        assertThat(result.status()).isEqualTo(AttendanceStatus.LEAVE);
+        assertThat(result.checkInTime()).isNull();
+        assertThat(result.checkOutTime()).isNull();
+    }
+
+    @Test
+    void updateAttendanceStatusTransitionPreservesBothTimesTest() {
+        ChildResponse child = createTestChild();
+
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate, AttendanceStatus.CHECKED_IN));
+        AttendanceDto checkedOut = attendanceService.updateAttendance(
+                new AttendanceRequest(child.id(), testDate, AttendanceStatus.CHECKED_OUT));
+
+        assertThat(checkedOut.status()).isEqualTo(AttendanceStatus.CHECKED_OUT);
+        assertThat(checkedOut.checkInTime()).isNotNull();
+        assertThat(checkedOut.checkOutTime()).isNotNull();
+    }
+
+    // --- getAttendanceHistory ---
+
+    @Test
+    void getAttendanceHistoryChildNotFoundTest() {
+        assertThatExceptionOfType(NotFoundException.class).isThrownBy(
+                () -> attendanceService.getAttendanceHistory(1L))
+                .withMessage("Child not found");
+    }
+
+    @Test
+    void getAttendanceHistoryEmptyForChildWithNoAttendanceTest() {
+        ChildResponse child = createTestChild();
+        assertThat(attendanceService.getAttendanceHistory(child.id())).isEmpty();
+    }
+
+    @Test
+    void getAttendanceHistoryReturnsAllRecordsOrderedByDateDescTest() {
+        ChildResponse child = createTestChild();
+
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate, AttendanceStatus.CHECKED_IN));
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate.plusDays(1), AttendanceStatus.ABSENT));
+        attendanceService.updateAttendance(new AttendanceRequest(child.id(), testDate.plusDays(2), AttendanceStatus.CHECKED_OUT));
+
+        List<AttendanceDto> history = attendanceService.getAttendanceHistory(child.id());
+
+        assertThat(history).hasSize(3);
+        assertThat(history.get(0).status()).isEqualTo(AttendanceStatus.CHECKED_OUT);
+        assertThat(history.get(0).checkOutTime()).isNotNull();
+        assertThat(history.get(1).status()).isEqualTo(AttendanceStatus.ABSENT);
+        assertThat(history.get(2).status()).isEqualTo(AttendanceStatus.CHECKED_IN);
+        assertThat(history.get(2).checkInTime()).isNotNull();
     }
 }

--- a/backend/src/test/java/se/mistral/backend/ChildTests.java
+++ b/backend/src/test/java/se/mistral/backend/ChildTests.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.springframework.transaction.annotation.Transactional;
 import se.mistral.backend.attendance.AttendanceService;
+import se.mistral.backend.attendance.AttendanceStatus;
 import se.mistral.backend.attendance.dto.AttendanceRequest;
 import se.mistral.backend.child.ChildService;
 import se.mistral.backend.child.dto.AttendanceResponse;
@@ -60,7 +61,7 @@ public class ChildTests {
     void getAllChildrenWithAttendanceIfExistsEmptyTest() {
         List<AttendanceResponse> childList = childService.getAllChildrenWithAttendanceIfExists(LocalDate.parse("2026-04-01"));
 
-        assertThat(childList.isEmpty());
+        assertThat(childList).isEmpty();
     }
 
     @Test
@@ -72,7 +73,7 @@ public class ChildTests {
         assertThat(childList.getFirst().name()).isEqualTo(childResponse.name());
         assertThat(childList.getFirst().id()).isEqualTo(childResponse.id());
         assertThat(childList.getFirst().date()).isNull();
-        assertThat(childList.getFirst().present()).isNull();
+        assertThat(childList.getFirst().status()).isNull();
 
         assertThat(childList.size()).isEqualTo(1);
 
@@ -90,9 +91,9 @@ public class ChildTests {
 
         LocalDate testDate = LocalDate.of(2026, 4, 1);
 
-        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, true);
-        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, true);
-        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, true);
+        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, AttendanceStatus.CHECKED_IN);
 
         attendanceService.updateAttendance(request1);
         attendanceService.updateAttendance(request2);
@@ -101,19 +102,19 @@ public class ChildTests {
         List<AttendanceResponse> childList = childService.getAllChildrenWithAttendanceIfExists(LocalDate.parse("2026-04-01"));
         assertThat(childList.size()).isEqualTo(3);
 
-        AttendanceResponse attendanceResponse1 = new AttendanceResponse(childResponse1.id(), childResponse1.name(), testDate, true);
-        AttendanceResponse attendanceResponse2 = new AttendanceResponse(childResponse2.id(), childResponse2.name(), testDate, true);
-        AttendanceResponse attendanceResponse3 = new AttendanceResponse(childResponse3.id(), childResponse3.name(), testDate, true);
+        AttendanceResponse attendanceResponse1 = new AttendanceResponse(childResponse1.id(), childResponse1.name(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceResponse attendanceResponse2 = new AttendanceResponse(childResponse2.id(), childResponse2.name(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceResponse attendanceResponse3 = new AttendanceResponse(childResponse3.id(), childResponse3.name(), testDate, AttendanceStatus.CHECKED_IN);
 
-        assertThat(childList.contains(attendanceResponse1));
-        assertThat(childList.contains(attendanceResponse2));
-        assertThat(childList.contains(attendanceResponse3));
+        assertThat(childList).contains(attendanceResponse1);
+        assertThat(childList).contains(attendanceResponse2);
+        assertThat(childList).contains(attendanceResponse3);
     }
 
     @Test
     void getAllChildrenWithAttendanceIfExistsInGroupEmptyTest() {
         List<AttendanceResponse> childList = childService.getAllChildrenWithAttendanceIfExistsInGroup(LocalDate.parse("2026-04-01"), 1L);
-        assertThat(childList.isEmpty());
+        assertThat(childList).isEmpty();
     }
 
     @Test
@@ -127,9 +128,9 @@ public class ChildTests {
         ChildResponse childResponse3 = childService.createChild(childRequest3);
         LocalDate testDate = LocalDate.of(2026, 4, 1);
 
-        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, true);
-        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, true);
-        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, true);
+        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, AttendanceStatus.CHECKED_IN);
 
         attendanceService.updateAttendance(request1);
         attendanceService.updateAttendance(request2);
@@ -151,9 +152,9 @@ public class ChildTests {
         ChildResponse childResponse3 = childService.createChild(childRequest3);
         LocalDate testDate = LocalDate.of(2026, 4, 1);
 
-        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, true);
-        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, true);
-        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, true);
+        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, AttendanceStatus.CHECKED_IN);
 
         attendanceService.updateAttendance(request1);
         attendanceService.updateAttendance(request2);
@@ -179,9 +180,9 @@ public class ChildTests {
         ChildResponse childResponse3 = childService.createChild(childRequest3);
         LocalDate testDate = LocalDate.of(2026, 4, 1);
 
-        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, true);
-        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, true);
-        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, true);
+        AttendanceRequest request1 = new AttendanceRequest(childResponse1.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request2 = new AttendanceRequest(childResponse2.id(), testDate, AttendanceStatus.CHECKED_IN);
+        AttendanceRequest request3 = new AttendanceRequest(childResponse3.id(), testDate, AttendanceStatus.CHECKED_IN);
 
         attendanceService.updateAttendance(request1);
         attendanceService.updateAttendance(request2);
@@ -224,7 +225,7 @@ public class ChildTests {
         List<ChildResponse> childList = childService.getChildrenByGroup(groupResponse.id());
 
         assertThat(childList.size()).isEqualTo(1);
-        assertThat(childList.contains(childResponse1));
+        assertThat(childList).contains(childResponse1);
     }
 
     @Test
@@ -248,9 +249,9 @@ public class ChildTests {
         List<ChildResponse> childList = childService.getChildrenByGroup(groupResponse.id());
 
         assertThat(childList.size()).isEqualTo(3);
-        assertThat(childList.contains(childResponse1));
-        assertThat(childList.contains(childResponse2));
-        assertThat(childList.contains(childResponse3));
+        assertThat(childList).contains(childResponse1);
+        assertThat(childList).contains(childResponse2);
+        assertThat(childList).contains(childResponse3);
 
     }
 

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -14,5 +14,5 @@ jwt.expiration-ms=864000000
 # test
 spring.datasource.url=jdbc:h2:mem:testDb;MODE=PostgreSQL
 spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/frontend/src/app/core/child/attendance.service.ts
+++ b/frontend/src/app/core/child/attendance.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, ReplaySubject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 export type AttendanceStatus = 'NOT_SET' | 'CHECKED_IN' | 'CHECKED_OUT' | 'LEAVE' | 'ABSENT';
@@ -22,9 +22,10 @@ export class AttendanceService {
 
   private url = `${environment.apiUrl}/api/attendance`;
   private attendanceSignals = new Map<string, ReturnType<typeof signal<AttendanceStatus | null>>>();
-
+  private attendanceChanges = new ReplaySubject<SetAttendanceRequest>();
   private http = inject(HttpClient);
 
+  readonly getAttendanceChanges = this.attendanceChanges.asObservable();
 
   getSignal(childId: number, dateStr: string) {
     const key = `${childId}_${dateStr}`;
@@ -40,7 +41,7 @@ export class AttendanceService {
       date,
       status,
     };
-
+    this.attendanceChanges.next(data);
     return this.http.put<AttendanceInfo>(this.url, data);
   }
 }

--- a/frontend/src/app/core/child/attendance.service.ts
+++ b/frontend/src/app/core/child/attendance.service.ts
@@ -3,28 +3,25 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
-export interface AttendanceSetInfo {
-  id: number;
-  childId: number;
-  date: string;
-  present: boolean;
-}
+export type AttendanceStatus = 'NOT_SET' | 'CHECKED_IN' | 'CHECKED_OUT' | 'LEAVE' | 'ABSENT';
 
-export interface AttendanceGetInfo {
-  present: boolean;
+export interface AttendanceInfo {
+  status: AttendanceStatus;
+  checkInTime: string | null;
+  checkOutTime: string | null;
 }
 
 interface SetAttendanceRequest {
   childId: number;
   date: string;
-  present: boolean;
+  status: AttendanceStatus;
 }
 
 @Injectable({ providedIn: 'root' })
 export class AttendanceService {
 
   private url = `${environment.apiUrl}/api/attendance`;
-  private attendanceSignals = new Map<string, ReturnType<typeof signal<boolean | null>>>();
+  private attendanceSignals = new Map<string, ReturnType<typeof signal<AttendanceStatus | null>>>();
 
   private http = inject(HttpClient);
 
@@ -32,19 +29,18 @@ export class AttendanceService {
   getSignal(childId: number, dateStr: string) {
     const key = `${childId}_${dateStr}`;
     if (!this.attendanceSignals.has(key)) {
-      this.attendanceSignals.set(key, signal<boolean | null>(null));
+      this.attendanceSignals.set(key, signal<AttendanceStatus | null>(null));
     }
     return this.attendanceSignals.get(key)!;
   }
 
-  setAttendance(childId: number, date: string, present: boolean): Observable<AttendanceSetInfo> {
+  setAttendance(childId: number, date: string, status: AttendanceStatus): Observable<AttendanceInfo> {
     const data: SetAttendanceRequest = {
       childId,
       date,
-      present,
+      status,
     };
 
-    return this.http.put<AttendanceSetInfo>(this.url, data);
+    return this.http.put<AttendanceInfo>(this.url, data);
   }
-
 }

--- a/frontend/src/app/core/child/child.service.ts
+++ b/frontend/src/app/core/child/child.service.ts
@@ -2,12 +2,13 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
+import { AttendanceStatus } from './attendance.service';
 
 export interface Child {
   id: number;
   name: string;
   date: string | null;
-  present: boolean | null;
+  status: AttendanceStatus | null;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/core/presence/presence.service.ts
+++ b/frontend/src/app/core/presence/presence.service.ts
@@ -22,7 +22,7 @@ export class Presence {
 
   spoofTeacherUpdate() {
     console.log("Spoofing teacher");
-    this._teacherUpdates.next({ name: "Spoof", id: -1, room: "Spoof", color: "#ffffff"});
+    this._teacherUpdates.next({ name: "Spoof", userId: -1, room: "Spoof", color: "#ffffff"});
   }
 
   /**
@@ -53,9 +53,9 @@ export class Presence {
     if (!msg.room)
       console.error("Incorrectly formatted leave message in presence service: ", msg);
 
-    const msgTeacher = { id: msg.userId, name: msg.name, room: msg.room!, color: msg.color};
+    const msgTeacher = { userId: msg.userId, name: msg.name, room: msg.room!, color: msg.color};
     const updated = this.connectedTeachers().filter((teacher: User) => {
-      return teacher.id != msg.userId;
+      return teacher.userId != msg.userId;
     });
     this.connectedTeachers.set(updated);
     console.log("Someone left, new status: ", this.connectedTeachers());
@@ -71,10 +71,10 @@ export class Presence {
       console.error("Incorrectly formatted join message in presence service: ", msg);
 
     const index = this.connectedTeachers().findIndex((teacher: User) => {
-      return teacher.id == msg.userId;
+      return teacher.userId == msg.userId;
     });
 
-    const msgTeacher: User = { id: msg.userId, name: msg.name, room: msg.room!, color: msg.color};
+    const msgTeacher: User = { userId: msg.userId, name: msg.name, room: msg.room!, color: msg.color};
 
     if (index == -1) {
       const updated = this.connectedTeachers();

--- a/frontend/src/app/core/user/user.service.ts
+++ b/frontend/src/app/core/user/user.service.ts
@@ -7,7 +7,8 @@ import { environment } from '../../../environments/environment';
 export interface User {
   name: string,
   room: string,
-  id: number,
+  userId: number,
+  id?: number,
   color: string,
   role?: string,
   email?: string,

--- a/frontend/src/app/core/websocket/websocket.service.ts
+++ b/frontend/src/app/core/websocket/websocket.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import {Observable, ReplaySubject, Subject } from 'rxjs';
+import { Observable, ReplaySubject, Subject } from 'rxjs';
 import { User } from '../user/user.service';
+import { AttendanceStatus } from '../child/attendance.service';
 
 const DEBUG = true;
 
@@ -29,7 +30,7 @@ export interface WsPresenceChangeMessage extends WsMessageContent {
 
 export interface WsAttendanceMessage extends WsMessageContent {
   childId: number,
-  present: boolean
+  status: AttendanceStatus;
 }
 
 export interface WsJournalMessage extends WsMessageContent {

--- a/frontend/src/app/routes/main-page/attendance-box/attendance-box.html
+++ b/frontend/src/app/routes/main-page/attendance-box/attendance-box.html
@@ -1,12 +1,17 @@
 <div>
-    <mat-checkbox
-        [disabled]="disabled()"
-        [checked]="isChecked"
-        (change)="onCheckBox($event)">
-        <!--Enbart låda lägg till egen text i respektive html dokument-->
-    </mat-checkbox>
+  @if (disabled()) {
+    <span>{{ statusLabels[currentStatus] }}</span>
+  } @else {
+    <mat-form-field appearance="outline" subscriptSizing="dynamic">
+      <mat-select [value]="currentStatus" (selectionChange)="onStatusChange($event.value)">
+        @for (option of statusOptions; track option.value) {
+          <mat-option [value]="option.value">{{ option.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  }
 
-    @if (errorMessage) {
-        <p class="error-text">{{ errorMessage }}</p>
-    }
+  @if (errorMessage) {
+    <p class="error-text">{{ errorMessage }}</p>
+  }
 </div>

--- a/frontend/src/app/routes/main-page/attendance-box/attendance-box.scss
+++ b/frontend/src/app/routes/main-page/attendance-box/attendance-box.scss
@@ -3,3 +3,8 @@
     font-size: 16px;
     position: absolute;
 }
+
+mat-form-field {
+    --mat-form-field-container-height: 32px;
+    --mat-form-field-container-vertical-padding: 6px;
+}

--- a/frontend/src/app/routes/main-page/attendance-box/attendance-box.ts
+++ b/frontend/src/app/routes/main-page/attendance-box/attendance-box.ts
@@ -1,16 +1,14 @@
 import { Component, input, effect, inject, model, EventEmitter, Output } from '@angular/core';
-import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { Child } from '../../../core/child/child.service';
-import { AttendanceService } from '../../../core/child/attendance.service';
-import { MatDialog } from '@angular/material/dialog';
-import { ConfirmationDialog } from '../confirmation-dialog/confirmation-dialog';
-import { firstValueFrom } from 'rxjs';
+import { AttendanceService, AttendanceStatus } from '../../../core/child/attendance.service';
 import { WsAttendanceMessage } from '../../../core/websocket/websocket.service';
 import { localDateToday } from '../../../core/utils/date-utils';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 @Component({
   selector: 'attendance-box',
-  imports: [MatCheckboxModule],
+  imports: [MatSelectModule, MatFormFieldModule],
   templateUrl: './attendance-box.html',
   styleUrl: './attendance-box.scss',
 })
@@ -18,13 +16,24 @@ export class AttendanceBox {
   childSignal = model.required<Child>();
   disabled = input<boolean>();
   errorMessage = '';
-  dialog = inject(MatDialog);
 
-  get isChecked(): boolean {
-    return this.attendanceService.getSignal(this.childSignal().id, localDateToday())() ?? false;
-  }
+  readonly statusOptions: { value: AttendanceStatus; label: string }[] = [
+    { value: 'NOT_SET',     label: '—'         },
+    { value: 'CHECKED_IN',  label: 'Incheckad' },
+    { value: 'CHECKED_OUT', label: 'Utcheckad' },
+    { value: 'LEAVE',       label: 'Ledig'      },
+    { value: 'ABSENT',      label: 'Sjuk'       },
+  ];
+
+  readonly statusLabels = Object.fromEntries(
+    this.statusOptions.map(o => [o.value, o.label])
+  ) as Record<AttendanceStatus, string>;
 
   private attendanceService = inject(AttendanceService);
+
+  get currentStatus(): AttendanceStatus {
+    return this.attendanceService.getSignal(this.childSignal().id, localDateToday())() ?? 'NOT_SET';
+  }
 
   constructor() {
     effect(() => {
@@ -33,61 +42,35 @@ export class AttendanceBox {
 
       const sig = this.attendanceService.getSignal(child.id, localDateToday());
       if (sig() === null) {
-        if (child.present === null) {
-          sig.set(false);
-        } else {
-          sig.set(child.present);
-        }
+        sig.set(child.status ?? 'NOT_SET');
       }
     });
   }
 
-  async onCheckBox(event: MatCheckboxChange) {
-
-    const newStatus = event.checked;
-
-    if (newStatus === false) {
-      event.source.checked = true;
-
-      const confirmed = await this.confirmation();
-
-      if(!confirmed) { // early return
-        return;
-      }
-    }
-
+  onStatusChange(newStatus: AttendanceStatus) {
     const sig = this.attendanceService.getSignal(this.childSignal().id, localDateToday());
+    const previousStatus = sig();
     sig.set(newStatus);
 
     this.attendanceService.setAttendance(this.childSignal().id, localDateToday(), newStatus).subscribe({
-      next: (data) => sig.set(data.present),
+      next: (data) => sig.set(data.status),
       error: (err) => {
         console.error('Kunde inte spara', err);
-        sig.set(!newStatus);
-        event.source.checked = !newStatus;
+        sig.set(previousStatus);
         this.errorMessage = 'Misslyckades att spara till databasen.';
         setTimeout(() => this.errorMessage = '', 2000);
       },
     });
 
-    this.wsUpdateAttendance(event.checked)
+    this.wsUpdateAttendance(newStatus);
   }
 
   @Output() attendanceChangeEvent = new EventEmitter();
-  wsUpdateAttendance(checked: boolean) {
+  wsUpdateAttendance(status: AttendanceStatus) {
     const msg: WsAttendanceMessage = {
       childId: this.childSignal().id,
-      present: checked
-    }
+      status
+    };
     this.attendanceChangeEvent.emit(msg);
-  }
-
-  async confirmation() {
-    const dialogRef = this.dialog.open(ConfirmationDialog, {
-      height: '120px',
-      width: '400px',
-    });
-    const result = await firstValueFrom(dialogRef.afterClosed());
-    return result;
   }
 }

--- a/frontend/src/app/routes/main-page/attendance-box/attendance-box.ts
+++ b/frontend/src/app/routes/main-page/attendance-box/attendance-box.ts
@@ -22,7 +22,7 @@ export class AttendanceBox {
     { value: 'CHECKED_IN',  label: 'Incheckad' },
     { value: 'CHECKED_OUT', label: 'Utcheckad' },
     { value: 'LEAVE',       label: 'Ledig'      },
-    { value: 'ABSENT',      label: 'Sjuk'       },
+    { value: 'ABSENT',      label: 'Frånvarande' },
   ];
 
   readonly statusLabels = Object.fromEntries(

--- a/frontend/src/app/routes/main-page/child-display/child-display.html
+++ b/frontend/src/app/routes/main-page/child-display/child-display.html
@@ -1,4 +1,4 @@
-<div class="columnise"> 
+<div class="columnise">
     <p>{{getDate()}}</p>
     <div class="rowise">
         Närvaro:

--- a/frontend/src/app/routes/main-page/child-display/child-display.scss
+++ b/frontend/src/app/routes/main-page/child-display/child-display.scss
@@ -9,4 +9,5 @@
     display: flex;
     flex-direction: row;
     align-items: baseline;
+    gap: 12px;
 }

--- a/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
+++ b/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
@@ -41,7 +41,7 @@ export class ChildList {
   });
 
   groupAttendance = computed(() => {
-    return this.searchedChildren().filter(x => x.status === 'CHECKED_IN' || x.status === 'CHECKED_OUT').length;
+    return this.searchedChildren().filter(x => x.status === 'CHECKED_IN').length;
   })
 
   groupAbsent = computed(() => {

--- a/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
+++ b/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
@@ -38,7 +38,7 @@ export class ChildList {
   });
 
   groupAttendance = computed(() => {
-    return this.searchedChildren().filter(x => x.present === true).length;
+    return this.searchedChildren().filter(x => x.status === 'CHECKED_IN' || x.status === 'CHECKED_OUT').length;
   })
 
   groupAbsent = computed(() => {
@@ -60,10 +60,6 @@ export class ChildList {
   onSearchUpdated(sq: string) {
     console.log(this.groupSignal().name)
     this.searchQuery.set(sq);
-  }
-
-  get isChecked(): boolean {
-    return this.attendanceService.getSignal(this.childSignal().id, localDateToday())() ?? false;
   }
 
   onSelectChild(child: Child) {
@@ -110,6 +106,6 @@ export class ChildList {
     }
 
     const sig = this.attendanceService.getSignal(targetChild.id, localDateToday());
-    sig.set(message.present);
+    sig.set(message.status);
   }
 }

--- a/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
+++ b/frontend/src/app/routes/main-page/main-child-list/main-child-list.ts
@@ -31,8 +31,11 @@ export class ChildList {
   groupSignal = model.required<groupResponse>();
   contentSignal = model.required<string>();
   allGroups = model.required<groupResponse[]>();
+  stupidFix = signal<number>(0);
+
 
   searchedChildren = computed(() => {
+    this.stupidFix();
     const sq = this.searchQuery();
     return this.children().filter(x => x.name.toLowerCase().includes(sq));
   });
@@ -46,9 +49,21 @@ export class ChildList {
   })
 
   private attendanceService = inject(AttendanceService);
+
   private childService = inject(ChildService);
 
   constructor() {
+    this.attendanceService.getAttendanceChanges.subscribe((next) => {
+      const targetChild: Child | undefined = this.children().find((child: Child) => {
+        return child.id === next.childId;
+      });
+      if (targetChild == null) {
+        return;
+      }
+      targetChild.status = next.status;
+      this.stupidFix.update((x) => x + 1);
+    });
+
     effect(() => {
       const group = this.groupSignal();
       if (group.id !== 0) {
@@ -99,13 +114,13 @@ export class ChildList {
     const targetChild: Child | undefined = this.children().find((child: Child) => {
       return child.id === message.childId;
     });
-
     if (!targetChild) {
-      alert("Child not found");
+      console.error("Attendance message received from other group. Child not found.");
       return;
     }
-
     const sig = this.attendanceService.getSignal(targetChild.id, localDateToday());
     sig.set(message.status);
+    targetChild.status = message.status;
+    this.stupidFix.update((x) => x + 1);
   }
 }

--- a/frontend/src/app/routes/main-page/main-panel/main-panel.html
+++ b/frontend/src/app/routes/main-page/main-panel/main-panel.html
@@ -43,8 +43,8 @@
     <mat-card class="main-card-right">
       <div class="main-card-right">
         <main-child-list
-          [(childSignal)]="childSignal"
           [(groupSignal)]="groupSignal"
+          [(childSignal)]="childSignal"
           [(contentSignal)]="contentSignal"
           [(allGroups)]="allGroups">
       </main-child-list>

--- a/frontend/src/app/routes/main-page/main-panel/main-panel.ts
+++ b/frontend/src/app/routes/main-page/main-panel/main-panel.ts
@@ -19,7 +19,7 @@ import { Presence } from '../../../core/presence/presence.service';
 })
 export class MainPanel implements OnInit{
   presence = inject(Presence);
-  childSignal = signal<Child>({ name: '', id: 0, date: "", present: false });
+  childSignal = signal<Child>({ name: '', id: 0, date: "", status: "NOT_SET" });
   contentSignal = model.required<string>();
   groupSignal = signal<groupResponse>({name: '', id: 0});
   allGroups = signal<groupResponse[]>([]);


### PR DESCRIPTION
Update attendance to use status enum instead of boolean                                                                                                                              
                                                                                                                                                                                       
  Replaces the boolean present field with a five-state AttendanceStatus enum across the full stack.                                                                                    
                                                                                                                                                                                       
  Backend                                 
  - Added AttendanceStatus enum: NOT_SET, CHECKED_IN, CHECKED_OUT, LEAVE, ABSENT                                                                                                       
  - Flyway migrations (V15–V17): removed present column, added status, check_in_time, check_out_time                                                                                   
  - Updated Attendance entity, DTOs, service and repository                                         
  - Added GET /api/attendance/history endpoint                                                                                                                                         
                                                                                                                                                                                       
  Frontend                                                                                                                                                                             
  - Replaced checkbox in attendance box with a mat-select dropdown showing all five statuses in Swedish                                                                                
  - In the child list, status is shown as a plain text label (no dropdown arrow)                                                                                                       
  - Updated AttendanceService, Child interface, WsAttendanceMessage and main-child-list to use the new status type                                                                     
  - Fixed groupAttendance computed to count CHECKED_IN and CHECKED_OUT as present  