### PR TITLE
Chore/tests for ot

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -43,6 +43,11 @@
 			<scope>test</scope>
 		</dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
         <!-- JWT - JJWT -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>

--- a/backend/src/test/java/se/mistral/backend/JournalServiceTests.java
+++ b/backend/src/test/java/se/mistral/backend/JournalServiceTests.java
@@ -85,7 +85,7 @@ public class JournalServiceTests {
     }
 
     @Test
-    void getOrCreateIsIdempotent() {
+    void getOrCreateReturnsSameInstanceOnMultipleCalls() {
         final JournalDto first = journalService.getOrCreate(CHILD, DATE);
         final JournalDto second = journalService.getOrCreate(CHILD, DATE);
 

--- a/backend/src/test/java/se/mistral/backend/JournalServiceTests.java
+++ b/backend/src/test/java/se/mistral/backend/JournalServiceTests.java
@@ -1,0 +1,197 @@
+package se.mistral.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import se.mistral.backend.child.ChildService;
+import se.mistral.backend.child.dto.ChildResponse;
+import se.mistral.backend.child.dto.CreateChildRequest;
+import se.mistral.backend.group.GroupService;
+import se.mistral.backend.group.dto.CreateGroupRequest;
+import se.mistral.backend.group.dto.GroupResponse;
+import se.mistral.backend.journal.JournalService;
+import se.mistral.backend.journal.JournalTarget;
+import se.mistral.backend.journal.dto.BroadcastMessage;
+import se.mistral.backend.journal.dto.JournalDto;
+import se.mistral.backend.journal.ot.Operation;
+import se.mistral.backend.user.Role;
+import se.mistral.backend.user.User;
+import se.mistral.backend.user.UserRepository;
+
+@SpringBootTest
+@Transactional
+public class JournalServiceTests {
+
+    @Autowired
+    private JournalService journalService;
+    @Autowired
+    private ChildService childService;
+    @Autowired
+    private GroupService groupService;
+    @Autowired
+    private UserRepository userRepository;
+
+    private static final LocalDate DATE = LocalDate.now();
+
+    private JournalTarget.Child CHILD;
+    private JournalTarget.Group GROUP;
+
+    private Long USER_A;
+    private Long USER_B;
+
+    @BeforeEach
+    void setUp() {
+        final ChildResponse child = childService.createChild(new CreateChildRequest("journal-test-child"));
+        final GroupResponse group = groupService.createGroup(new CreateGroupRequest("journal-test-group"));
+        CHILD = new JournalTarget.Child(child.id());
+        GROUP = new JournalTarget.Group(group.id());
+        User userA = userRepository.save(User.builder()
+                .name("Test User A")
+                .email("test-a@test.com")
+                .password("ignored")
+                .role(Role.TEACHER)
+                .build());
+        User userB = userRepository.save(User.builder()
+                .name("Test User B")
+                .email("test-b@test.com")
+                .password("ignored")
+                .role(Role.TEACHER)
+                .build());
+
+        USER_A = userA.getId();
+        USER_B = userB.getId();
+    }
+
+    @Test
+    void getOrCreateChildJournalShouldReturnEmptyContent() {
+        final JournalDto dto = journalService.getOrCreate(CHILD, DATE);
+
+        assertThat(dto.content()).isEqualTo("");
+        assertThat(dto.serverRevision()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void getOrCreateGroupJournalShouldReturnEmptyContent() {
+        final JournalDto dto = journalService.getOrCreate(GROUP, DATE);
+
+        assertThat(dto.content()).isEqualTo("");
+    }
+
+    @Test
+    void getOrCreateIsIdempotent() {
+        final JournalDto first = journalService.getOrCreate(CHILD, DATE);
+        final JournalDto second = journalService.getOrCreate(CHILD, DATE);
+
+        assertThat(first.content()).isEqualTo(second.content());
+        assertThat(first.serverRevision()).isEqualTo(second.serverRevision());
+    }
+
+    @Test
+    void getOrCreateIsSeparatePerDate() {
+        journalService.applyOperation(CHILD, DATE, 0, insert(0, "hello"), USER_A, null);
+        final JournalDto other = journalService.getOrCreate(CHILD, DATE.plusDays(1));
+
+        assertThat(other.content()).isEqualTo("");
+    }
+
+    @Test
+    void getOrCreateIsSeparatePerTarget() {
+        journalService.applyOperation(CHILD, DATE, 0, insert(0, "child content"), USER_A, null);
+        final JournalDto groupJournal = journalService.getOrCreate(GROUP, DATE);
+
+        assertThat(groupJournal.content()).isEqualTo("");
+    }
+
+    @Test
+    void singleInsertShouldUpdateContent() {
+        final BroadcastMessage result = journalService.applyOperation(CHILD, DATE, 0, insert(0, "hello"), USER_A, null);
+
+        assertThat(result.operation().getText()).isEqualTo("hello");
+        assertThat(journalService.getOrCreate(CHILD, DATE).content()).isEqualTo("hello");
+    }
+
+    @Test
+    void sequentialInsertsShouldAccumulateContent() {
+        journalService.applyOperation(CHILD, DATE, 0, insert(0, "hello"), USER_A, 1);
+        journalService.applyOperation(CHILD, DATE, 1, insert(5, " world"), USER_A, 2);
+
+        assertThat(journalService.getOrCreate(CHILD, DATE).content()).isEqualTo("hello world");
+    }
+
+    @Test
+    void singleDeleteShouldUpdateContent() {
+        journalService.applyOperation(CHILD, DATE, 0, insert(0, "hello world"), USER_A, 1);
+        journalService.applyOperation(CHILD, DATE, 1, delete(5, 6), USER_A, 2);
+
+        assertThat(journalService.getOrCreate(CHILD, DATE).content()).isEqualTo("hello");
+    }
+
+    @Test
+    void deleteAtEndOfContentShouldClampGracefully() {
+        journalService.applyOperation(CHILD, DATE, 0, insert(0, "hi"), USER_A, 1);
+        journalService.applyOperation(CHILD, DATE, 1, delete(1, 999), USER_A, 2);
+
+        assertThat(journalService.getOrCreate(CHILD, DATE).content()).isEqualTo("h");
+    }
+
+    @Test
+    void broadcastMessageShouldCarryCorrectMetadata() {
+        final BroadcastMessage result = journalService.applyOperation(CHILD, DATE, 0, insert(0, "hello"), USER_A, 7);
+
+        assertThat(result.type()).isEqualTo("DOC_OPERATION");
+        assertThat(result.userId()).isEqualTo(USER_A);
+        assertThat(result.sequence()).isEqualTo(7);
+    }
+
+    @Test
+    void broadcastMessageWithNullSequenceShouldBeAllowed() {
+        final BroadcastMessage result = journalService.applyOperation(CHILD, DATE, 0, insert(0, "hello"), USER_A, null);
+
+        assertThat(result.sequence()).isNull();
+    }
+
+    @Test
+    void serverRevisionShouldIncrementWithEachOperation() {
+        final BroadcastMessage first = journalService.applyOperation(CHILD, DATE, 0, insert(0, "a"), USER_A, 1);
+        final BroadcastMessage second = journalService.applyOperation(CHILD, DATE, first.serverRevision(),
+                insert(1, "b"), USER_A,
+                2);
+
+        assertThat(second.serverRevision()).isGreaterThan(first.serverRevision());
+    }
+
+    @Test
+    void concurrentInsertsFromDifferentUsersShouldBeTransformed() {
+        journalService.applyOperation(CHILD, DATE, 0, insert(0, "hello"), USER_A, null);
+        journalService.applyOperation(CHILD, DATE, 1, insert(2, "X"), USER_A, null);
+        journalService.applyOperation(CHILD, DATE, 1, insert(4, "Y"), USER_B, null);
+
+        final JournalDto dto = journalService.getOrCreate(CHILD, DATE);
+        assertThat(dto.content()).contains("X");
+        assertThat(dto.content()).contains("Y");
+        assertThat(dto.content()).hasSize(7);
+    }
+
+    @Test
+    void operationFromSameUserIsNotTransformed() {
+        journalService.applyOperation(CHILD, DATE, 0, insert(0, "abc"), USER_A, 1);
+        journalService.applyOperation(CHILD, DATE, 0, insert(3, "d"), USER_A, 2);
+
+        assertThat(journalService.getOrCreate(CHILD, DATE).content()).isEqualTo("abcd");
+    }
+
+    private Operation insert(final int pos, final String text) {
+        return Operation.builder().type(Operation.Type.INSERT).position(pos).text(text).build();
+    }
+
+    private Operation delete(final int pos, final int length) {
+        return Operation.builder().type(Operation.Type.DELETE).position(pos).length(length).build();
+    }
+}

--- a/backend/src/test/java/se/mistral/backend/OperationTransformerTests.java
+++ b/backend/src/test/java/se/mistral/backend/OperationTransformerTests.java
@@ -1,0 +1,247 @@
+package se.mistral.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.mistral.backend.journal.ot.Operation.Type.DELETE;
+import static se.mistral.backend.journal.ot.Operation.Type.INSERT;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import se.mistral.backend.journal.ot.Operation;
+import se.mistral.backend.journal.ot.OperationTransformer;
+
+class OperationTransformerTests {
+
+    private final OperationTransformer transformer = new OperationTransformer();
+
+    private Operation insert(final int pos, final String text) {
+        return Operation.builder().type(INSERT).position(pos).text(text).build();
+    }
+
+    private Operation delete(final int pos, final int length) {
+        return Operation.builder().type(DELETE).position(pos).length(length).build();
+    }
+
+    @Nested
+    class InsertVsInsert {
+
+        @Test
+        void concurrentBeforeIncoming() {
+            final Operation incoming = insert(3, "X");
+            final Operation concurrent = insert(1, "AB");
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(5);
+            assertThat(result.getText()).isEqualTo("X");
+        }
+
+        @Test
+        void concurrentAtSamePosition() {
+            final Operation incoming = insert(3, "X");
+            final Operation concurrent = insert(3, "AB");
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(5);
+        }
+
+        @Test
+        void concurrentAfterIncoming() {
+            final Operation incoming = insert(2, "X");
+            final Operation concurrent = insert(5, "AB");
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class InsertVsDelete {
+
+        @Test
+        void concurrentDeleteBeforeIncoming() {
+            final Operation incoming = insert(7, "X");
+            final Operation concurrent = delete(1, 2);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(5);
+        }
+
+        @Test
+        void concurrentDeleteOverlappingIncoming() {
+            final Operation incoming = insert(4, "X");
+            final Operation concurrent = delete(2, 4);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(2);
+        }
+
+        @Test
+        void concurrentDeleteAfterIncoming() {
+            final Operation incoming = insert(2, "X");
+            final Operation concurrent = delete(5, 3);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class DeleteVsInsert {
+
+        @Test
+        void concurrentInsertBeforeDelete() {
+            final Operation incoming = delete(3, 2);
+            final Operation concurrent = insert(1, "AB");
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(5);
+            assertThat(result.getLength()).isEqualTo(2);
+        }
+
+        @Test
+        void concurrentInsertInsideDeleteRange() {
+            final Operation incoming = delete(2, 5);
+            final Operation concurrent = insert(4, "XX");
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(2);
+            assertThat(result.getLength()).isEqualTo(7);
+        }
+
+        @Test
+        void concurrentInsertAfterDeleteRange() {
+            final Operation incoming = delete(1, 3);
+            final Operation concurrent = insert(8, "XX");
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(1);
+            assertThat(result.getLength()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    class DeleteVsDelete {
+
+        @Test
+        void concurrentDeleteBeforeIncoming() {
+            final Operation incoming = delete(7, 3);
+            final Operation concurrent = delete(2, 2);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(5);
+            assertThat(result.getLength()).isEqualTo(3);
+        }
+
+        @Test
+        void concurrentDeleteAfterIncoming() {
+            final Operation incoming = delete(1, 3);
+            final Operation concurrent = delete(6, 2);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(1);
+            assertThat(result.getLength()).isEqualTo(3);
+        }
+
+        @Test
+        void concurrentDeleteOverlapsFromLeft() {
+            final Operation incoming = delete(4, 4);
+            final Operation concurrent = delete(2, 4);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(2);
+            assertThat(result.getLength()).isEqualTo(2);
+        }
+
+        @Test
+        void concurrentDeleteOverlapsFromRight() {
+            final Operation incoming = delete(2, 5);
+            final Operation concurrent = delete(5, 4);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(2);
+            assertThat(result.getLength()).isEqualTo(3);
+        }
+
+        @Test
+        void concurrentDeleteFullyContainsIncoming() {
+            final Operation incoming = delete(3, 2);
+            final Operation concurrent = delete(1, 8);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getLength()).isEqualTo(0);
+        }
+
+        @Test
+        void incomingDeleteFullyContainsConcurrent() {
+            final Operation incoming = delete(1, 8);
+            final Operation concurrent = delete(3, 2);
+
+            final Operation result = transformer.transform(incoming, concurrent);
+
+            assertThat(result.getPosition()).isEqualTo(1);
+            assertThat(result.getLength()).isEqualTo(6);
+        }
+    }
+
+    @Nested
+    class Convergence {
+
+        @Test
+        void twoConcurrentInserts() {
+            final String base = "hello";
+            final Operation opA = insert(2, "X");
+            final Operation opB = insert(4, "Y");
+
+            final String afterA = applyOp(base, opA);
+            final Operation opB2 = transformer.transform(opB, opA);
+            final String afterAB = applyOp(afterA, opB2);
+
+            final String afterB = applyOp(base, opB);
+            final Operation opA2 = transformer.transform(opA, opB);
+            final String afterBA = applyOp(afterB, opA2);
+
+            assertThat(afterAB).isEqualTo(afterBA);
+        }
+
+        @Test
+        void insertAndDeleteConverge() {
+            final String base = "hello world";
+            final Operation opA = insert(5, "!");
+            final Operation opB = delete(6, 5);
+
+            final String afterA = applyOp(base, opA);
+            final Operation opB2 = transformer.transform(opB, opA);
+            final String afterAB = applyOp(afterA, opB2);
+
+            final String afterB = applyOp(base, opB);
+            final Operation opA2 = transformer.transform(opA, opB);
+            final String afterBA = applyOp(afterB, opA2);
+
+            assertThat(afterAB).isEqualTo(afterBA);
+        }
+
+        private String applyOp(final String content, final Operation op) {
+            final int pos = Math.max(0, Math.min(op.getPosition(), content.length()));
+            if (op.getType() == INSERT) {
+                return content.substring(0, pos) + op.getText() + content.substring(pos);
+            } else {
+                final int end = Math.min(pos + op.getLength(), content.length());
+                return content.substring(0, pos) + content.substring(end);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/se/mistral/backend/WebSocketHandlerTests.java
+++ b/backend/src/test/java/se/mistral/backend/WebSocketHandlerTests.java
@@ -1,0 +1,476 @@
+package se.mistral.backend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import se.mistral.backend.auth.JwtService;
+import se.mistral.backend.chat.dto.ChatMessage;
+import se.mistral.backend.child.ChildService;
+import se.mistral.backend.child.dto.ChildResponse;
+import se.mistral.backend.child.dto.CreateChildRequest;
+import se.mistral.backend.group.GroupService;
+import se.mistral.backend.group.dto.CreateGroupRequest;
+import se.mistral.backend.group.dto.GroupResponse;
+import se.mistral.backend.journal.JournalService;
+import se.mistral.backend.journal.JournalTarget;
+import se.mistral.backend.journal.dto.JournalDto;
+import se.mistral.backend.user.Role;
+import se.mistral.backend.user.User;
+import se.mistral.backend.user.UserRepository;
+import se.mistral.backend.websocket.MyWebSocketHandler;
+
+@SpringBootTest
+@Transactional
+public class WebSocketHandlerTests {
+
+    @Autowired
+    private MyWebSocketHandler handler;
+    @Autowired
+    private JwtService jwtService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ChildService childService;
+    @Autowired
+    private GroupService groupService;
+    @Autowired
+    private JournalService journalService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private static final LocalDate DATE = LocalDate.now();
+
+    private User userA;
+    private User userB;
+    private String tokenA;
+    private String tokenB;
+
+    @BeforeEach
+    void setUp() {
+        userA = userRepository.save(User.builder()
+                .name("User A")
+                .email("user-a@test.com")
+                .password("ignored")
+                .role(Role.TEACHER)
+                .color("#ff0000")
+                .build());
+
+        userB = userRepository.save(User.builder()
+                .name("User B")
+                .email("user-b@test.com")
+                .password("ignored")
+                .role(Role.TEACHER)
+                .color("#0000ff")
+                .build());
+
+        tokenA = jwtService.generateToken(userA);
+        tokenB = jwtService.generateToken(userB);
+    }
+
+    @Test
+    void validTokenShouldStoreUserAttributesOnSession() throws Exception {
+        final WebSocketSession session = mockSession(tokenA);
+
+        handler.afterConnectionEstablished(session);
+
+        final Map<String, Object> attrs = session.getAttributes();
+        assertThat(attrs.get("userId")).isEqualTo(userA.getId());
+        assertThat(attrs.get("userName")).isEqualTo("User A");
+        assertThat(attrs.get("userColor")).isEqualTo("#ff0000");
+    }
+
+    @Test
+    void validTokenShouldSendPresenceState() throws Exception {
+        final WebSocketSession session = mockSession(tokenA);
+
+        handler.afterConnectionEstablished(session);
+
+        final ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getValue().getPayload()).contains("PRESENCE_STATE");
+    }
+
+    @Test
+    void missingTokenShouldCloseSession() throws Exception {
+        final WebSocketSession session = mockSession(null);
+
+        handler.afterConnectionEstablished(session);
+
+        verify(session).close(CloseStatus.NOT_ACCEPTABLE);
+    }
+
+    @Test
+    void invalidTokenShouldCloseSession() throws Exception {
+        final WebSocketSession session = mockSession("not.a.valid.token");
+
+        handler.afterConnectionEstablished(session);
+
+        verify(session).close(CloseStatus.NOT_ACCEPTABLE);
+    }
+
+    @Test
+    void subscribeToJournalShouldBroadcastPresenceJoin() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+        final WebSocketSession sessionB = openSession(tokenB);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+
+        subscribe(sessionB, room);
+        clearInvocations(sessionB);
+
+        subscribe(sessionA, room);
+
+        final ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(sessionB, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getValue().getPayload()).contains("PRESENCE_JOIN");
+        assertThat(captor.getValue().getPayload()).contains(userA.getId().toString());
+    }
+
+    @Test
+    void unsubscribeFromJournalShouldBroadcastPresenceLeave() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+        final WebSocketSession sessionB = openSession(tokenB);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+
+        subscribe(sessionA, room);
+        subscribe(sessionB, room);
+        clearInvocations(sessionA, sessionB);
+
+        unsubscribe(sessionA, room);
+
+        final ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(sessionB, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getValue().getPayload()).contains("PRESENCE_LEAVE");
+    }
+
+    @Test
+    void subscribeToChatAsNonMemberShouldCloseSession() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final String room = "chat:" + userB.getId() + ":" + (userB.getId() + 99);
+        subscribe(sessionA, room);
+
+        verify(sessionA).close(CloseStatus.NOT_ACCEPTABLE);
+    }
+
+    @Test
+    void subscribeToChatAsMemberShouldSucceed() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final String room = "chat:" + userA.getId() + ":" + userB.getId();
+        subscribe(sessionA, room);
+
+        verify(sessionA, never()).close(any());
+    }
+
+    @Test
+    void closingSessionShouldBroadcastPresenceLeaveForAllJoinedRooms() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+        final WebSocketSession sessionB = openSession(tokenB);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+
+        subscribe(sessionA, room);
+        subscribe(sessionB, room);
+        clearInvocations(sessionA, sessionB);
+
+        handler.afterConnectionClosed(sessionA, CloseStatus.NORMAL);
+
+        final ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(sessionB, atLeastOnce()).sendMessage(captor.capture());
+        assertThat(captor.getValue().getPayload()).contains("PRESENCE_LEAVE");
+    }
+
+    @Test
+    void closingSessionWithNoRoomsShouldNotThrow() throws Exception {
+        final WebSocketSession session = mockSession(null);
+
+        handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+
+        verify(session, never()).sendMessage(any());
+    }
+
+    @Test
+    void validChatMessageShouldBeDeliveredToRecipient() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+        final WebSocketSession sessionB = openSession(tokenB);
+
+        final String room = "chat:" + userA.getId() + ":" + userB.getId();
+        subscribe(sessionA, room);
+        subscribe(sessionB, room);
+        clearInvocations(sessionA, sessionB);
+
+        final String payload = objectMapper.writeValueAsString(new SocketMessage(
+                "CHAT_MESSAGE",
+                room,
+                new ChatMessage(
+                        userA.getId(),
+                        userB.getId(),
+                        "hello",
+                        LocalDateTime.now())));
+
+        handler.handleTextMessage(sessionA, new TextMessage(payload));
+
+        final ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(sessionB, atLeastOnce()).sendMessage(captor.capture());
+        verify(sessionA, never()).sendMessage(any());
+
+        final String received = captor.getValue().getPayload();
+        assertThat(received).contains("hello");
+        assertThat(received).contains(userA.getId().toString());
+    }
+
+    @Test
+    void chatMessageToNonChatRoomShouldCloseSession() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final String payload = objectMapper.writeValueAsString(new SocketMessage(
+                "CHAT_MESSAGE",
+                "journal:child:1:2026-01-01",
+                new ChatMessage(
+                        userA.getId(),
+                        userB.getId(),
+                        "hello",
+                        LocalDateTime.now())));
+
+        handler.handleTextMessage(sessionA, new TextMessage(payload));
+
+        verify(sessionA).close(CloseStatus.NOT_ACCEPTABLE);
+    }
+
+    @Test
+    void chatMessageWithSpoofedSenderIdShouldCloseSession() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final String payload = objectMapper.writeValueAsString(new SocketMessage(
+                "CHAT_MESSAGE",
+                "chat:" + userA.getId() + ":" + userB.getId(),
+                new ChatMessage(
+                        userB.getId(),
+                        userA.getId(),
+                        "hello",
+                        LocalDateTime.now())));
+
+        handler.handleTextMessage(sessionA, new TextMessage(payload));
+
+        verify(sessionA).close(CloseStatus.NOT_ACCEPTABLE);
+    }
+
+    @Test
+    void chatMessageWithWrongRecipientShouldCloseSession() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final String payload = objectMapper.writeValueAsString(new SocketMessage(
+                "CHAT_MESSAGE",
+                "chat:" + userA.getId() + ":" + userB.getId(),
+                new ChatMessage(
+                        userA.getId(),
+                        userA.getId(),
+                        "hello",
+                        LocalDateTime.now())));
+
+        handler.handleTextMessage(sessionA, new TextMessage(payload));
+
+        verify(sessionA).close(CloseStatus.NOT_ACCEPTABLE);
+    }
+
+    @Test
+    void validDocOperationShouldBeBroadcastToAllSubscribers() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+        final WebSocketSession sessionB = openSession(tokenB);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+
+        subscribe(sessionA, room);
+        subscribe(sessionB, room);
+        clearInvocations(sessionA, sessionB);
+
+        handler.handleTextMessage(sessionA, docOperation(room, 0, insertOp(0, "hello"), null));
+
+        final ArgumentCaptor<TextMessage> captorA = ArgumentCaptor.forClass(TextMessage.class);
+        final ArgumentCaptor<TextMessage> captorB = ArgumentCaptor.forClass(TextMessage.class);
+        verify(sessionA, atLeastOnce()).sendMessage(captorA.capture());
+        verify(sessionB, atLeastOnce()).sendMessage(captorB.capture());
+
+        assertThat(captorA.getValue().getPayload()).contains("DOC_OPERATION");
+        assertThat(captorB.getValue().getPayload()).contains("DOC_OPERATION");
+    }
+
+    @Test
+    void docOperationShouldPersistContentToJournal() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+        subscribe(sessionA, room);
+
+        handler.handleTextMessage(sessionA, docOperation(room, 0, insertOp(0, "hello"), 1));
+
+        final JournalDto dto = journalService.getOrCreate(new JournalTarget.Child(child.id()), DATE);
+        assertThat(dto.content()).isEqualTo("hello");
+    }
+
+    @Test
+    void docOperationBroadcastShouldIncludeServerRevisionAndUserId() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+        subscribe(sessionA, room);
+        clearInvocations(sessionA);
+
+        handler.handleTextMessage(sessionA, docOperation(room, 0, insertOp(0, "hello"), 5));
+
+        final ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(sessionA, atLeastOnce()).sendMessage(captor.capture());
+
+        final String payload = captor.getValue().getPayload();
+        assertThat(payload).contains("serverRevision");
+        assertThat(payload).contains(userA.getId().toString());
+        assertThat(payload).contains("5");
+    }
+
+    @Test
+    void docOperationOnGroupJournalShouldPersistContent() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final GroupResponse group = groupService.createGroup(new CreateGroupRequest("ws-test-group"));
+        final String room = "journal:group:" + group.id() + ":" + DATE;
+        subscribe(sessionA, room);
+
+        handler.handleTextMessage(sessionA, docOperation(room, 0, insertOp(0, "group note"), null));
+
+        final JournalDto dto = journalService.getOrCreate(new JournalTarget.Group(group.id()), DATE);
+        assertThat(dto.content()).isEqualTo("group note");
+    }
+
+    @Test
+    void docOperationToNonJournalRoomShouldBeIgnored() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final String room = "chat:" + userA.getId() + ":" + userB.getId();
+
+        handler.handleTextMessage(sessionA, docOperation(room, 0, insertOp(0, "hello"), null));
+
+        verify(sessionA).close(any());
+    }
+
+    @Test
+    void sequentialDocOperationsShouldAccumulateInJournal() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+        subscribe(sessionA, room);
+
+        handler.handleTextMessage(sessionA, docOperation(room, 0, insertOp(0, "hello"), 1));
+        handler.handleTextMessage(sessionA, docOperation(room, 1, insertOp(5, " world"), 2));
+
+        final JournalDto dto = journalService.getOrCreate(new JournalTarget.Child(child.id()), DATE);
+        assertThat(dto.content()).isEqualTo("hello world");
+    }
+
+    @Test
+    void deleteDocOperationShouldRemoveContentFromJournal() throws Exception {
+        final WebSocketSession sessionA = openSession(tokenA);
+
+        final ChildResponse child = childService.createChild(new CreateChildRequest("ws-test-child"));
+        final String room = "journal:child:" + child.id() + ":" + DATE;
+        subscribe(sessionA, room);
+
+        handler.handleTextMessage(sessionA, docOperation(room, 0, insertOp(0, "hello world"), 1));
+        handler.handleTextMessage(sessionA, docOperation(room, 1, deleteOp(5, 6), 2));
+
+        final JournalDto dto = journalService.getOrCreate(new JournalTarget.Child(child.id()), DATE);
+        assertThat(dto.content()).isEqualTo("hello");
+    }
+
+    private WebSocketSession mockSession(final String token) throws IOException {
+        final WebSocketSession session = mock(WebSocketSession.class);
+        final Map<String, Object> attrs = new HashMap<>();
+        if (token != null) {
+            attrs.put("token", token);
+        }
+        when(session.getAttributes()).thenReturn(attrs);
+        when(session.isOpen()).thenReturn(true);
+        return session;
+    }
+
+    private WebSocketSession openSession(final String token) throws Exception {
+        final WebSocketSession session = mockSession(token);
+        handler.afterConnectionEstablished(session);
+        return session;
+    }
+
+    private void subscribe(final WebSocketSession session, final String room) throws Exception {
+        final String payload = objectMapper.writeValueAsString(Map.of(
+                "type", "subscribe",
+                "room", room));
+        handler.handleTextMessage(session, new TextMessage(payload));
+    }
+
+    private void unsubscribe(final WebSocketSession session, final String room) throws Exception {
+        final String payload = objectMapper.writeValueAsString(Map.of(
+                "type", "unsubscribe",
+                "room", room));
+        handler.handleTextMessage(session, new TextMessage(payload));
+    }
+
+    private TextMessage docOperation(final String room, final int clientRevision, final Map<String, Object> operation,
+            final Integer sequence)
+            throws Exception {
+        final Map<String, Object> payload = new HashMap<>();
+        payload.put("type", "DOC_OPERATION");
+        payload.put("room", room);
+        payload.put("clientRevision", clientRevision);
+        payload.put("operation", operation);
+        if (sequence != null) {
+            payload.put("sequence", sequence);
+        }
+        return new TextMessage(objectMapper.writeValueAsString(payload));
+    }
+
+    private Map<String, Object> insertOp(final int position, final String text) {
+        return Map.of("type", "INSERT", "position", position, "text", text);
+    }
+
+    private Map<String, Object> deleteOp(final int position, final int length) {
+        return Map.of("type", "DELETE", "position", position, "length", length);
+    }
+
+    public record SocketMessage(
+            String type,
+            String room,
+            ChatMessage message) {
+    }
+}


### PR DESCRIPTION
det saknas några test cases, men alla viktiga fall täcks nu och coverage har gått upp från 3% till 90% i `se.mistral.backend.websocket`, 9% till 88% i `se.mistral.backend.journal.ot`, 0% till 74% i `se.mistral.backend.journal`. 0% till 100% i `se.mistral.backend.websocket.dto` och `se.mistral.backend.journal.dto`.

Coverage ligger nu på 77% totalt